### PR TITLE
Ktc/manager edit and delete shift in teams fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,4 @@ ASALocalRun/
 /Kronos-Shifts-Connector/api/.vscode
 Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Properties/ServiceDependencies/kwfcteamsdev-api - Web Deploy/profile.arm.json
 Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Properties/ServiceDependencies/kwfcteamsdev-config - Web Deploy/profile.arm.json
+Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Microsoft.Teams.Shifts.Integration.API.xml

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/Microsoft.Teams.App.KronosWfc.BusinessLogic.csproj
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/Microsoft.Teams.App.KronosWfc.BusinessLogic.csproj
@@ -240,6 +240,10 @@
       <Project>{eeee133b-08d5-4f99-901e-47ccd9e683bd}</Project>
       <Name>Microsoft.Teams.App.KronosWfc.Service</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.Teams.Shifts.Integration.Common\Microsoft.Teams.Shifts.Integration.BusinessLogic.csproj">
+      <Project>{CD5E9375-3DC5-4134-A8A0-5B9CFF5BE9F7}</Project>
+      <Name>Microsoft.Teams.Shifts.Integration.BusinessLogic</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/Shifts/IShiftsActivity.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/Shifts/IShiftsActivity.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Teams.App.KronosWfc.BusinessLogic.Shifts
     using System.Threading.Tasks;
     using Microsoft.Teams.App.KronosWfc.Models.RequestEntities.Common;
     using Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.HyperFind;
-    using CRUDRequest = Microsoft.Teams.App.KronosWfc.Models.RequestEntities.Shifts.ShiftRequest;
     using CRUDResponse = Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Common.Response;
     using UpcomingShifts = Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Shifts.UpcomingShifts;
 
@@ -44,7 +43,6 @@ namespace Microsoft.Teams.App.KronosWfc.BusinessLogic.Shifts
         /// <param name="overADateBorder">Whether the shift spans over a date border.</param>
         /// <param name="jobPath">The job of the shift.</param>
         /// <param name="kronosId">The id of the employee.</param>
-        /// <param name="shiftLabel">The label for the shift.</param>
         /// <param name="startTime">The start time of the shift.</param>
         /// <param name="endTime">The end time of the shift.</param>
         /// <returns>A task containing the response.</returns>
@@ -56,9 +54,34 @@ namespace Microsoft.Teams.App.KronosWfc.BusinessLogic.Shifts
             bool overADateBorder,
             string jobPath,
             string kronosId,
-            string shiftLabel,
             string startTime,
             string endTime);
+
+        /// <summary>
+        /// Edits a shift in Kronos.
+        /// </summary>
+        /// <param name="endpoint">The endpoint for the request.</param>
+        /// <param name="jSession">The Jsession token.</param>
+        /// <param name="shiftStartDate">The start date of the shift.</param>
+        /// <param name="shiftEndDate">The end date of the shift.</param>
+        /// <param name="overADateBorder">Whether the shift spans over a date border.</param>
+        /// <param name="jobPath">The job of the shift.</param>
+        /// <param name="kronosId">The id of the employee.</param>
+        /// <param name="startTime">The start time of the shift.</param>
+        /// <param name="endTime">The end time of the shift.</param>
+        /// <param name="shiftsOnSameDay">A list of any shifts that start on the same day as the edited shift.</param>
+        /// <returns>A task containing the response.</returns>
+        Task<CRUDResponse> EditShift(
+            Uri endpoint,
+            string jSession,
+            string shiftStartDate,
+            string shiftEndDate,
+            bool overADateBorder,
+            string jobPath,
+            string kronosId,
+            string startTime,
+            string endTime,
+            List<ScheduleShift> shiftsOnSameDay);
 
         /// <summary>
         /// Deletes a shift in Kronos.

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.Common/ApiConstants.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.Common/ApiConstants.cs
@@ -255,6 +255,11 @@ namespace Microsoft.Teams.App.KronosWfc.Common
         public const string AddScheduleItems = "AddScheduleItems";
 
         /// <summary>
+        /// Defines the action for editing schedule items.
+        /// </summary>
+        public const string EditScheduleItems = "EditScheduleItems";
+
+        /// <summary>
         /// Defines the action for deleting schedule items.
         /// </summary>
         public const string RemoveSpecifiedScheduleItems = "RemoveSpecifiedScheduleItems";

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/Utility.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/Utility.cs
@@ -1083,7 +1083,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
         /// <param name="date">A <see cref="DateTime"/>.</param>
         /// <returns>A string representation of the date for a kronos call.</returns>
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "This format is needed for kronos calls.")]
-        public string ConvertToKronosDate(DateTime date) => date.ToString(this.appSettings.KronosQueryDateSpanFormat);
+        public string FormatDateForKronos(DateTime date) => date.ToString(this.appSettings.KronosQueryDateSpanFormat);
 
         /// <summary>
         /// Method to retrieve the necessary details from AppSettings.

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var creationResponse = await this.openShiftActivity.CreateOpenShiftAsync(
                 new Uri(allRequiredConfigurations.WfmEndPoint),
                 allRequiredConfigurations.KronosSession,
-                this.utility.ConvertToKronosDate(openShiftDetails.KronosStartDateTime),
-                this.utility.ConvertToKronosDate(openShiftDetails.KronosEndDateTime),
+                this.utility.FormatDateForKronos(openShiftDetails.KronosStartDateTime),
+                this.utility.FormatDateForKronos(openShiftDetails.KronosEndDateTime),
                 openShiftDetails.KronosEndDateTime.Day > openShiftDetails.KronosStartDateTime.Day,
                 Utility.OrgJobPathKronosConversion(openShiftOrgJobPath),
                 openShiftDetails.DisplayName,
@@ -124,8 +124,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             }
 
             var monthPartitionKey = Utility.GetMonthPartition(
-                this.utility.ConvertToKronosDate(openShiftDetails.KronosStartDateTime),
-                this.utility.ConvertToKronosDate(openShiftDetails.KronosEndDateTime));
+                this.utility.FormatDateForKronos(openShiftDetails.KronosStartDateTime),
+                this.utility.FormatDateForKronos(openShiftDetails.KronosEndDateTime));
 
             await this.CreateAndStoreOpenShiftMapping(openShift, team, monthPartitionKey.FirstOrDefault(), openShiftOrgJobPath).ConfigureAwait(false);
 

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -186,8 +186,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var deletionResponse = await this.shiftsActivity.DeleteShift(
                 new Uri(allRequiredConfigurations.WfmEndPoint),
                 allRequiredConfigurations.KronosSession,
-                this.utility.ConvertToKronosDate(kronosStartDateTime),
-                this.utility.ConvertToKronosDate(kronosEndDateTime),
+                this.utility.FormatDateForKronos(kronosStartDateTime),
+                this.utility.FormatDateForKronos(kronosEndDateTime),
                 kronosEndDateTime.Day > kronosStartDateTime.Day,
                 Utility.OrgJobPathKronosConversion(user.PartitionKey),
                 user.RowKey,
@@ -229,8 +229,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var creationResponse = await this.shiftsActivity.CreateShift(
                 new Uri(allRequiredConfigurations.WfmEndPoint),
                 allRequiredConfigurations.KronosSession,
-                this.utility.ConvertToKronosDate(kronosStartDateTime),
-                this.utility.ConvertToKronosDate(kronosEndDateTime),
+                this.utility.FormatDateForKronos(kronosStartDateTime),
+                this.utility.FormatDateForKronos(kronosEndDateTime),
                 kronosEndDateTime.Day > kronosStartDateTime.Day,
                 Utility.OrgJobPathKronosConversion(user.PartitionKey),
                 user.RowKey,
@@ -242,7 +242,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 return CreateBadResponse(shift.Id, error: "Shift was not created successfully in Kronos.");
             }
 
-            var monthPartitionKey = Utility.GetMonthPartition(this.utility.ConvertToKronosDate(kronosStartDateTime), this.utility.ConvertToKronosDate(kronosEndDateTime));
+            var monthPartitionKey = Utility.GetMonthPartition(this.utility.FormatDateForKronos(kronosStartDateTime), this.utility.FormatDateForKronos(kronosEndDateTime));
 
             await this.CreateAndStoreShiftMapping(shift, user, mappedTeam, monthPartitionKey).ConfigureAwait(false);
 
@@ -265,9 +265,9 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 return response;
             }
 
-            // We need to give all other shifts the employee works that day so retrieve them from DB.
+            // We need to get all other shifts the employee works that day.
             var (kronosStartDateTime, kronosEndDateTime) = this.GetConvertedShiftDetails(editedShift, mappedTeam);
-            var monthPartitionKey = Utility.GetMonthPartition(this.utility.ConvertToKronosDate(kronosStartDateTime), this.utility.ConvertToKronosDate(kronosEndDateTime));
+            var monthPartitionKey = Utility.GetMonthPartition(this.utility.FormatDateForKronos(kronosStartDateTime), this.utility.FormatDateForKronos(kronosEndDateTime));
 
             var usersShifts = await this.shiftMappingEntityProvider.GetAllUsersShiftsByPartitionKeyAsync(monthPartitionKey.First(), user.ShiftUserAadObjectId).ConfigureAwait(false);
 
@@ -280,16 +280,16 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var additionalShifts = this.ProcessSameDayShifts(shiftsOnSameDay, mappedTeam, user);
 
             var editResponse = await this.shiftsActivity.EditShift(
-            new Uri(allRequiredConfigurations.WfmEndPoint),
-            allRequiredConfigurations.KronosSession,
-            this.utility.ConvertToKronosDate(kronosStartDateTime),
-            this.utility.ConvertToKronosDate(kronosEndDateTime),
-            kronosEndDateTime.Day > kronosStartDateTime.Day,
-            Utility.OrgJobPathKronosConversion(user.PartitionKey),
-            user.RowKey,
-            kronosStartDateTime.TimeOfDay.ToString(),
-            kronosEndDateTime.TimeOfDay.ToString(),
-            additionalShifts).ConfigureAwait(false);
+                new Uri(allRequiredConfigurations.WfmEndPoint),
+                allRequiredConfigurations.KronosSession,
+                this.utility.FormatDateForKronos(kronosStartDateTime),
+                this.utility.FormatDateForKronos(kronosEndDateTime),
+                kronosEndDateTime.Day > kronosStartDateTime.Day,
+                Utility.OrgJobPathKronosConversion(user.PartitionKey),
+                user.RowKey,
+                kronosStartDateTime.TimeOfDay.ToString(),
+                kronosEndDateTime.TimeOfDay.ToString(),
+                additionalShifts).ConfigureAwait(false);
 
             if (editResponse.Status != Success)
             {
@@ -758,7 +758,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                 var additionalShift = new ScheduleShift
                 {
-                    StartDate = this.utility.ConvertToKronosDate(additionalShiftStartDate),
+                    StartDate = this.utility.FormatDateForKronos(additionalShiftStartDate),
                     ShiftSegments = new ShiftSegments().Create(
                         additionalShiftStartDate.TimeOfDay.ToString(),
                         additionalShiftEndDate.TimeOfDay.ToString(),

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/SwapShiftEligibilityController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/SwapShiftEligibilityController.cs
@@ -86,14 +86,14 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var offeredStartTime = startDate.TimeOfDay.ToString();
             var offeredEndTime = endDate.TimeOfDay.ToString();
-            var offeredShiftDate = this.utility.ConvertToKronosDate(startDate);
-            var swapShiftDate = this.utility.ConvertToKronosDate(endDate);
+            var offeredShiftDate = this.utility.FormatDateForKronos(startDate);
+            var swapShiftDate = this.utility.FormatDateForKronos(endDate);
             var days = this.GetDateList();
             List<TeamsShiftMappingEntity> eligibleShifts = new List<TeamsShiftMappingEntity>();
 
             foreach (var day in days)
             {
-                var kronosDate = this.utility.ConvertToKronosDate(day);
+                var kronosDate = this.utility.FormatDateForKronos(day);
                 var eligibleEmployees = await this.swapShiftEligibilityActivity.SendEligibilityRequestAsync(
                     new Uri(configuration.WfmEndPoint),
                     configuration.KronosSession,

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -389,34 +389,6 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         }
 
         /// <summary>
-        /// This method will generate the necessary response for acknowledging the open shift being created or changed.
-        /// </summary>
-        /// <param name="jsonModel">The decrypted JSON payload.</param>
-        /// <param name="updateProps">The type of <see cref="Dictionary{TKey, TValue}"/> which contains various properties to log to ApplicationInsights.</param>
-        /// <returns>A type of <see cref="ShiftsIntegResponse"/>.</returns>
-        private static ShiftsIntegResponse ProcessOpenShiftAcknowledgement(RequestModel jsonModel, Dictionary<string, string> updateProps)
-        {
-            ShiftsIntegResponse integrationResponse;
-            if (jsonModel.Requests.First(x => x.Url.Contains("/openshifts/", StringComparison.InvariantCulture)).Body != null)
-            {
-                var incomingOpenShift = JsonConvert.DeserializeObject<OpenShiftIS>(jsonModel.Requests.First().Body.ToString());
-
-                updateProps.Add("OpenShiftId", incomingOpenShift.Id);
-                updateProps.Add("SchedulingGroupId", incomingOpenShift.SchedulingGroupId);
-
-                integrationResponse = CreateSuccessfulResponse(incomingOpenShift.Id);
-            }
-            else
-            {
-                var nullBodyIncomingOpenShiftId = jsonModel.Requests.First(x => x.Url.Contains("/openshifts/", StringComparison.InvariantCulture)).Id;
-                updateProps.Add("NullBodyOpenShiftId", nullBodyIncomingOpenShiftId);
-                integrationResponse = CreateSuccessfulResponse(nullBodyIncomingOpenShiftId);
-            }
-
-            return integrationResponse;
-        }
-
-        /// <summary>
         /// This method will properly decrypt the encrypted payload that is being received from Shifts.
         /// </summary>
         /// <param name="secretKeyBytes">The sharedSecret from Shifts casted into a byte array.</param>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -298,15 +298,14 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     {
                         if (shift.DraftShift?.IsActive == false || shift.SharedShift?.IsActive == false)
                         {
-                            // This looks like an issue with shifts sending a PUT for both edits and deletes, so it looks for the isActive flag instead.
-                            // This is currently disabled since there is a problem with the Kronos endpoint that prevents it from working as intended.
-                            // response = await this.shiftController.DeleteShiftFromKronos(shift, user, mappedTeam).ConfigureAwait(false);
+                            // Manager deleted a shift.
+                            response = await this.shiftController.DeleteShiftFromKronos(shift, user, mappedTeam).ConfigureAwait(false);
                             return CreateSuccessfulResponse(shift.Id);
                         }
                         else
                         {
-                            // This is currently disabled since there is a problem with the Kronos endpoint that prevents it from working as intended.
-                            // response = await this.shiftController.EditShiftInKronos(shift, user, mappedTeam).ConfigureAwait(false);
+                            // Manager edited a shift.
+                            response = await this.shiftController.EditShiftInKronos(shift, user, mappedTeam).ConfigureAwait(false);
                             return CreateSuccessfulResponse(shift.Id);
                         }
                     }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IShiftMappingEntityProvider.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IShiftMappingEntityProvider.cs
@@ -47,11 +47,9 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
         /// Method that would be able to return based on the PartitionKey, hash, and Shift "ID".
         /// </summary>
         /// <param name="monthPartition">The month partition.</param>
-        /// <param name="rowKey">The Row Key for the shift entity mapping.</param>
-        /// <returns>A unit of execution that contains TeamsShiftMapping.</returns>
-        Task<TeamsShiftMappingEntity> GetShiftEntityAsync(
-            string monthPartition,
-            string rowKey);
+        /// <param name="aadUserId">The Row Key for the shift entity mapping.</param>
+        /// <returns>List of TeamsShiftMapping.</returns>
+        Task<List<TeamsShiftMappingEntity>> GetAllUsersShiftsByPartitionKeyAsync(string monthPartition, string aadUserId);
 
         /// <summary>
         /// Method that retrieves a temporary shift.

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/ShiftMappingEntityProvider.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/ShiftMappingEntityProvider.cs
@@ -36,16 +36,8 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             this.initializeTask = new Lazy<Task>(() => this.InitializeAsync(connectionString));
         }
 
-        /// <summary>
-        /// This method returns the necessary row(s) that are to have their row key properly updated with
-        /// the actual shift ID from MS Graph APIs post-OpenShiftRequest Approval.
-        /// </summary>
-        /// <param name="monthPartition">The month partition.</param>
-        /// <param name="rowKey">A "temp" row key.</param>
-        /// <returns>A unit of execution.</returns>
-        public async Task<TeamsShiftMappingEntity> GetShiftEntityAsync(
-            string monthPartition,
-            string rowKey)
+        /// <inheritdoc/>
+        public async Task<List<TeamsShiftMappingEntity>> GetAllUsersShiftsByPartitionKeyAsync(string monthPartition, string aadUserId)
         {
             await this.EnsureInitializedAsync().ConfigureAwait(false);
 
@@ -57,12 +49,11 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, getEntitiesProps);
 
             string monthPartitionFilter = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, monthPartition);
-            string startDateFilter = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, monthPartition);
-            string rowKeyFilter = TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.Equal, rowKey);
+            string aadIdFilter = TableQuery.GenerateFilterCondition("AadUserId", QueryComparisons.Equal, aadUserId);
 
             // Table query
             TableQuery<TeamsShiftMappingEntity> query = new TableQuery<TeamsShiftMappingEntity>();
-            query.Where(TableQuery.CombineFilters(monthPartitionFilter, TableOperators.And, rowKeyFilter));
+            query.Where(TableQuery.CombineFilters(monthPartitionFilter, TableOperators.And, aadIdFilter));
 
             // Results list
             var results = new List<TeamsShiftMappingEntity>();
@@ -76,7 +67,7 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             }
             while (continuationToken != null);
 
-            return results.FirstOrDefault();
+            return results;
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed DeleteShift to only delete specified shift rather than all shifts for that orgJobPath
- Implemented a new method for editing a shift 
- Removed unused method from the Teams controller