### PR TITLE
Ktc/month partition bug fix

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.Models/ResponseEntities/Shifts/UpcomingShifts/ScheduleItems.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.Models/ResponseEntities/Shifts/UpcomingShifts/ScheduleItems.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Shifts.UpcomingShifts
 {
+    using System.Collections.Generic;
     using System.Xml.Serialization;
 
     /// <summary>
@@ -15,9 +16,10 @@ namespace Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Shifts.UpcomingS
         /// Gets or sets the scheduleShift.
         /// </summary>
         [XmlElement("ScheduleShift", typeof(ScheduleShift))]
-#pragma warning disable CA1819 // Properties should not return arrays
-        public ScheduleShift[] ScheduleShift { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+#pragma warning disable CA2227 // Collection properties should be read only
+        public List<ScheduleShift> ScheduleShifts { get; set; }
+
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets the schedulePayCodeEdit.
@@ -25,6 +27,7 @@ namespace Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Shifts.UpcomingS
         [XmlElement("SchedulePayCodeEdit", typeof(SchedulePayCodeEdit))]
 #pragma warning disable CA1819 // Properties should not return arrays
         public SchedulePayCodeEdit[] SchedulePayCodeEdit { get; set; }
+
 #pragma warning restore CA1819 // Properties should not return arrays
     }
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ControllerHelper.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ControllerHelper.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Microsoft.Teams.App.KronosWfc.Common;
     using Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI.Incoming;
@@ -72,6 +73,34 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             // Filter all the system declined requests.
             return openShiftRequests.Where(c => c.Body?["state"].Value<string>() == ApiConstants.Declined
                 && c.Body["assignedTo"].Value<string>() == ApiConstants.System).ToList();
+        }
+
+        /// <summary>
+        /// Filters a list of entities, ensuring that the entity starts within the provided
+        /// query date range.
+        /// </summary>
+        /// <param name="entities">The entities to filter.</param>
+        /// <param name="queryStartDate">The date the entity must start after.</param>
+        /// <param name="queryEndDate">The date the entity must start before.</param>
+        /// <returns>A list of filtered entities.</returns>
+        public static List<T> FilterEntitiesByQueryDateSpan<T>(List<T> entities, string queryStartDate, string queryEndDate)
+        {
+            var filteredEntities = new List<T>();
+            var querystartDateTime = DateTime.Parse(queryStartDate, CultureInfo.InvariantCulture);
+            var queryEndDateTime = DateTime.Parse(queryEndDate, CultureInfo.InvariantCulture);
+
+            foreach (var entity in entities)
+            {
+                dynamic obj = entity;
+                var entityStartDate = DateTime.Parse(obj.StartDate, CultureInfo.InvariantCulture);
+
+                if (entityStartDate.Date >= querystartDateTime.Date && entityStartDate.Date <= queryEndDateTime.Date)
+                {
+                    filteredEntities.Add(entity);
+                }
+            }
+
+            return filteredEntities;
         }
     }
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers;
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.ResponseModels;
     using Newtonsoft.Json;
+    using OpenShiftBatch = Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.OpenShift.Batch;
     using SetupDetails = Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI.SetupDetails;
 
     /// <summary>
@@ -245,25 +246,28 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                 foreach (var openShiftSchedule in openShiftsResponse?.Schedules.Where(x => x.OrgJobPath == orgJob))
                                 {
                                     this.telemetryClient.TrackTrace($"OpenShiftController - Processing the Open Shift schedule for: {openShiftSchedule.OrgJobPath}, and date range: {openShiftSchedule.QueryDateSpan}");
-                                    var scheduleShiftCount = (int)openShiftSchedule.ScheduleItems?.ScheduleShifts?.Count;
 
-                                    if (scheduleShiftCount > 0)
+                                    // Kronos api returns any open shifts that occur in the date span provided.
+                                    // We want only the entities that started within the query date span.
+                                    var openShifts = this.RemoveOpenShiftsWithWrongStartDate(openShiftSchedule.ScheduleItems?.ScheduleShifts, queryStartDate, queryEndDate);
+
+                                    if (openShifts.Count > 0)
                                     {
                                         if (mappedOrgJobEntity != null)
                                         {
                                             this.telemetryClient.TrackTrace($"OpenShiftController - Processing Open Shifts for the mapped team: {mappedOrgJobEntity.ShiftsTeamName}");
 
                                             // This foreach builds the Open Shift object to push to Shifts via Graph API.
-                                            foreach (var scheduleShift in openShiftSchedule?.ScheduleItems?.ScheduleShifts)
+                                            foreach (var openShift in openShifts)
                                             {
-                                                var shiftSegmentCount = scheduleShift.ShiftSegments;
+                                                var shiftSegmentCount = openShift.ShiftSegments;
 
-                                                this.telemetryClient.TrackTrace($"OpenShiftController - Processing {scheduleShift.StartDate} with {shiftSegmentCount} segments.");
+                                                this.telemetryClient.TrackTrace($"OpenShiftController - Processing {openShift.StartDate} with {shiftSegmentCount} segments.");
 
                                                 var openShiftActivity = new List<Activity>();
 
                                                 // This foreach loop will build the OpenShift activities.
-                                                foreach (var segment in scheduleShift.ShiftSegments.ShiftSegment)
+                                                foreach (var segment in openShift.ShiftSegments.ShiftSegment)
                                                 {
                                                     openShiftActivity.Add(new Activity
                                                     {
@@ -282,7 +286,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                                     {
                                                         DisplayName = string.Empty,
                                                         OpenSlotCount = Constants.ShiftsOpenSlotCount,
-                                                        Notes = this.utility.GetOpenShiftNotes(scheduleShift),
+                                                        Notes = this.utility.GetOpenShiftNotes(openShift),
                                                         StartDateTime = openShiftActivity.First().StartDateTime,
                                                         EndDateTime = openShiftActivity.Last().EndDateTime,
                                                         Theme = this.appSettings.OpenShiftTheme,
@@ -326,7 +330,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                     }
                                     else
                                     {
-                                        this.telemetryClient.TrackTrace($"ScheduleShiftCount - {scheduleShiftCount} for {openShiftSchedule.OrgJobPath}");
+                                        this.telemetryClient.TrackTrace($"ScheduleShiftCount - {openShifts.Count} for {openShiftSchedule.OrgJobPath}");
                                         continue;
                                     }
                                 }
@@ -500,6 +504,32 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         }
 
         /// <summary>
+        /// Remove any open shifts that do not start before the provided end date.
+        /// </summary>
+        /// <param name="openShifts">The open shifts to filter.</param>
+        /// <param name="queryStartDate">The date the open shifts must start after.</param>
+        /// <param name="queryEndDate">The date the open shifts must start before.</param>
+        /// <returns>A list of filtered open shifts.</returns>
+        private List<OpenShiftBatch.ScheduleShift> RemoveOpenShiftsWithWrongStartDate(List<OpenShiftBatch.ScheduleShift> openShifts, string queryStartDate, string queryEndDate)
+        {
+            var filteredOpenShifts = new List<OpenShiftBatch.ScheduleShift>();
+            var batchStartDate = DateTime.Parse(queryStartDate, CultureInfo.InvariantCulture);
+            var batchEndDate = DateTime.Parse(queryEndDate, CultureInfo.InvariantCulture);
+
+            foreach (var openShift in openShifts)
+            {
+                var openShiftStartDate = DateTime.Parse(openShift.StartDate, CultureInfo.InvariantCulture);
+
+                if (openShiftStartDate.Date >= batchStartDate.Date && openShiftStartDate.Date <= batchEndDate.Date)
+                {
+                    filteredOpenShifts.Add(openShift);
+                }
+            }
+
+            return filteredOpenShifts;
+        }
+
+        /// <summary>
         /// Method that will get the open shifts in a batch manner.
         /// </summary>
         /// <param name="workforceIntegrationId">The Workforce Integration Id.</param>
@@ -509,7 +539,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <param name="startDate">The start date.</param>
         /// <param name="endDate">The end date.</param>
         /// <returns>A unit of execution that contains the Kronos response model.</returns>
-        private async Task<App.KronosWfc.Models.ResponseEntities.OpenShift.Batch.Response> GetOpenShiftResultsByOrgJobPathInBatchAsync(
+        private async Task<OpenShiftBatch.Response> GetOpenShiftResultsByOrgJobPathInBatchAsync(
             string workforceIntegrationId,
             string kronosEndpoint,
             string jSession,
@@ -528,7 +558,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var openShiftQueryDateSpan = $"{startDate}-{endDate}";
 
-            var openShiftRequests = await this.openShiftActivity.GetOpenShiftDetailsInBatchAsync(
+            var openShifts = await this.openShiftActivity.GetOpenShiftDetailsInBatchAsync(
                 new Uri(kronosEndpoint),
                 jSession,
                 orgJobPathsList,
@@ -536,7 +566,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             this.telemetryClient.TrackTrace($"OpenShiftController - GetOpenShiftResultsByOrgJobPathInBatchAsync ended at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}");
 
-            return openShiftRequests;
+            return openShifts;
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                                 // Kronos api returns any shifts that occur in the date span provided.
                                 // We want only the entities that started within the query date span.
-                                var shifts = this.RemoveShiftsWithWrongStartDate(shiftsResponse?.Schedule?.ScheduleItems?.ScheduleShifts, queryStartDate, queryEndDate);
+                                var shifts = ControllerHelper.FilterEntitiesByQueryDateSpan(shiftsResponse?.Schedule?.ScheduleItems?.ScheduleShifts, queryStartDate, queryEndDate);
 
                                 if (shifts.Count == 0)
                                 {
@@ -545,32 +545,6 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             await this.CreateEntryShiftsEntityMappingAsync(configurationDetails, userModelNotFoundList, shiftsNotFoundList, monthPartitionKey).ConfigureAwait(false);
 
             this.telemetryClient.TrackTrace($"ShiftController - ProcessShiftEntitiesBatchAsync ended at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}");
-        }
-
-        /// <summary>
-        /// Remove any shifts that do not start before the provided end date.
-        /// </summary>
-        /// <param name="shifts">The shifts to filter.</param>
-        /// <param name="queryStartDate">The date the shifts must start after.</param>
-        /// <param name="queryEndDate">The date the shifts must start before.</param>
-        /// <returns>A list of filtered shifts.</returns>
-        private List<UpcomingShiftsResponse.ScheduleShift> RemoveShiftsWithWrongStartDate(List<UpcomingShiftsResponse.ScheduleShift> shifts, string queryStartDate, string queryEndDate)
-        {
-            var filteredShifts = new List<UpcomingShiftsResponse.ScheduleShift>();
-            var batchStartDate = DateTime.Parse(queryStartDate, CultureInfo.InvariantCulture);
-            var batchEndDate = DateTime.Parse(queryEndDate, CultureInfo.InvariantCulture);
-
-            foreach (var shift in shifts)
-            {
-                var shiftStartDate = DateTime.Parse(shift.StartDate, CultureInfo.InvariantCulture);
-
-                if (shiftStartDate.Date >= batchStartDate.Date && shiftStartDate.Date <= batchEndDate.Date)
-                {
-                    filteredShifts.Add(shift);
-                }
-            }
-
-            return filteredShifts;
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -1128,10 +1128,10 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                     // confirm new shifts exists on kronos
                     var requestedShiftKronos = requestingUserShifts
-                        .Schedule.ScheduleItems.ScheduleShift
+                        .Schedule.ScheduleItems.ScheduleShifts
                         .FirstOrDefault(x => x.Employee.FirstOrDefault().PersonNumber == kronosRequestingUserId && x.StartDate == requestorShiftDate);
                     var requestorsShiftKronos = requestedUserShifts
-                        .Schedule.ScheduleItems.ScheduleShift
+                        .Schedule.ScheduleItems.ScheduleShifts
                         .FirstOrDefault(x => x.Employee.FirstOrDefault().PersonNumber == kronosRequestedUserId && x.StartDate == requestedShiftDate);
 
                     if (requestedShiftKronos != null && requestorsShiftKronos != null)


### PR DESCRIPTION
This PR fixes a bug which was causing duplicate entities when the entity ran across two months. ie. 11pm on the 31st until 5am on the 1st

This fix has been applied whenever syncing time off, open shifts and shifts from Kronos.