### PR TITLE
Ktc/block managers from using save button when modifying schedule

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             // Likewise there is no share schedule WFI call.
             if (openShift.DraftOpenShift?.StartDateTime != null)
             {
-                return ResponseHelper.CreateBadResponse(openShift.Id, error: "Creating draft open shifts is not supported. Please publish changes directly using the 'Share' button.");
+                return ResponseHelper.CreateBadResponse(openShift.Id, error: "Creating a draft open shift is not supported. Please publish changes directly using the 'Share' button.");
             }
 
             var allRequiredConfigurations = await this.utility.GetAllConfigurationsAsync().ConfigureAwait(false);

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -164,13 +164,13 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <param name="user">The user the shift is for.</param>
         /// <param name="mappedTeam">The team the user is in.</param>
         /// <returns>A response for teams.</returns>
-        public async Task<ShiftsIntegResponse> DeleteShiftFromKronos(ShiftsShift shift, AllUserMappingEntity user, TeamToDepartmentJobMappingEntity mappedTeam)
+        public async Task<ShiftsIntegResponse> DeleteShiftFromKTeamsAsync(ShiftsShift shift, AllUserMappingEntity user, TeamToDepartmentJobMappingEntity mappedTeam)
         {
             // The connector does not support drafting entities as it is not possible to draft shifts in Kronos.
             // Likewise there is no share schedule WFI call.
             if (shift.DraftShift?.StartDateTime != null)
             {
-                return ResponseHelper.CreateBadResponse(shift.Id, error: "Deleting shifts as a draft is not supported. Please publish changes directly using the 'Share' button.");
+                return ResponseHelper.CreateBadResponse(shift.Id, error: "Deleting a shift as a draft is not supported. Please publish changes directly using the 'Share' button.");
             }
 
             if (user.ErrorIfNull(shift.Id, "User could not be found.", out var response))
@@ -222,7 +222,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             // Likewise there is no share schedule WFI call.
             if (shift.DraftShift?.StartDateTime != null)
             {
-                return ResponseHelper.CreateBadResponse(shift.Id, error: "Creating draft shifts is not supported. Please publish changes directly using the 'Share' button.");
+                return ResponseHelper.CreateBadResponse(shift.Id, error: "Creating a draft shift is not supported. Please publish changes directly using the 'Share' button.");
             }
 
             if (user.ErrorIfNull(shift.Id, "User could not be found.", out var response))
@@ -270,13 +270,13 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <param name="user">The user the shift is for.</param>
         /// <param name="mappedTeam">The team the user is in.</param>
         /// <returns>A response for teams.</returns>
-        public async Task<ShiftsIntegResponse> EditShiftInKronos(ShiftsShift editedShift, AllUserMappingEntity user, TeamToDepartmentJobMappingEntity mappedTeam)
+        public async Task<ShiftsIntegResponse> EditShiftFromTeamsAsync(ShiftsShift editedShift, AllUserMappingEntity user, TeamToDepartmentJobMappingEntity mappedTeam)
         {
             // The connector does not support drafting entities as it is not possible to draft shifts in Kronos.
             // Likewise there is no share schedule WFI call.
             if (editedShift.DraftShift?.StartDateTime != null)
             {
-                return ResponseHelper.CreateBadResponse(editedShift.Id, error: "Editing shifts as a draft is not supported. Please publish changes directly using the 'Share' button.");
+                return ResponseHelper.CreateBadResponse(editedShift.Id, error: "Editing a shift as a draft is not supported. Please publish changes directly using the 'Share' button.");
             }
 
             var allRequiredConfigurations = await this.utility.GetAllConfigurationsAsync().ConfigureAwait(false);

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -279,9 +279,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             if (requestBody != null)
             {
                 var shift = ControllerHelper.Get<Shift>(jsonModel, "/shifts/");
-                var user = await this.userMappingProvider.GetUserMappingEntityAsyncNew(
-                    shift.UserId,
-                    shift.SchedulingGroupId).ConfigureAwait(false);
+                var user = await this.userMappingProvider.GetUserMappingEntityAsyncNew(shift.UserId, shift.SchedulingGroupId).ConfigureAwait(false);
 
                 if (isFromLogicApp)
                 {
@@ -359,13 +357,13 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     {
                         if (openShift.DraftOpenShift?.IsActive == false || openShift.SharedOpenShift?.IsActive == false)
                         {
-                            // This looks like a bug with shifts sending a PUT for both edits and deletes, so it looks for the isActive flag instead.
-                            //response = await this.openShiftController.DeleteShiftFromKronos(openShift, mappedTeam).ConfigureAwait(false);
+                            // We cannot support delete due to api limitations so block the action.
+                            response = CreateBadResponse(openShift.Id, error: "Deleting open shifts in Teams is not supported. Please make your changes in Kronos.");
                         }
                         else
                         {
-                            // Edit goes here
-                            response = CreateSuccessfulResponse(openShift.Id);
+                            // We cannot support edit due to api limitations so block the action.
+                            response = CreateBadResponse(openShift.Id, error: "Editing open shifts in Teams is not supported. Please make your changes in Kronos.");
                         }
                     }
                 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -297,12 +297,12 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                         if (shift.DraftShift?.IsActive == false || shift.SharedShift?.IsActive == false)
                         {
                             // Manager deleted a shift.
-                            response = await this.shiftController.DeleteShiftFromKronos(shift, user, mappedTeam).ConfigureAwait(false);
+                            response = await this.shiftController.DeleteShiftFromKTeamsAsync(shift, user, mappedTeam).ConfigureAwait(false);
                         }
                         else
                         {
                             // Manager edited a shift.
-                            response = await this.shiftController.EditShiftInKronos(shift, user, mappedTeam).ConfigureAwait(false);
+                            response = await this.shiftController.EditShiftFromTeamsAsync(shift, user, mappedTeam).ConfigureAwait(false);
                         }
                     }
                 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -290,19 +290,19 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 {
                     if (jsonModel.Requests.Any(c => c.Method == "POST"))
                     {
-                        response = await this.shiftController.CreateShiftFromTeamsAsync(shift, user, mappedTeam).ConfigureAwait(false);
+                        response = await this.shiftController.CreateShiftInKronosAsync(shift, user, mappedTeam).ConfigureAwait(false);
                     }
                     else if (jsonModel.Requests.Any(c => c.Method == "PUT"))
                     {
                         if (shift.DraftShift?.IsActive == false || shift.SharedShift?.IsActive == false)
                         {
                             // Manager deleted a shift.
-                            response = await this.shiftController.DeleteShiftFromKTeamsAsync(shift, user, mappedTeam).ConfigureAwait(false);
+                            response = await this.shiftController.DeleteShiftInKronosAsync(shift, user, mappedTeam).ConfigureAwait(false);
                         }
                         else
                         {
                             // Manager edited a shift.
-                            response = await this.shiftController.EditShiftFromTeamsAsync(shift, user, mappedTeam).ConfigureAwait(false);
+                            response = await this.shiftController.EditShiftInKronosAsync(shift, user, mappedTeam).ConfigureAwait(false);
                         }
                     }
                 }
@@ -349,7 +349,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 {
                     if (jsonModel.Requests.Any(c => c.Method == "POST"))
                     {
-                        response = await this.openShiftController.CreateOpenShiftFromTeamsAsync(openShift, mappedTeam).ConfigureAwait(false);
+                        response = await this.openShiftController.CreateOpenShiftInKronosAsync(openShift, mappedTeam).ConfigureAwait(false);
                     }
                     else if (jsonModel.Requests.Any(c => c.Method == "PUT"))
                     {

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 {
                     if (jsonModel.Requests.Any(c => c.Method == "POST"))
                     {
-                        response = await this.shiftController.AddShiftToKronos(shift, user, mappedTeam).ConfigureAwait(false);
+                        response = await this.shiftController.CreateShiftFromTeamsAsync(shift, user, mappedTeam).ConfigureAwait(false);
                     }
                     else if (jsonModel.Requests.Any(c => c.Method == "PUT"))
                     {
@@ -298,13 +298,11 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                         {
                             // Manager deleted a shift.
                             response = await this.shiftController.DeleteShiftFromKronos(shift, user, mappedTeam).ConfigureAwait(false);
-                            return CreateSuccessfulResponse(shift.Id);
                         }
                         else
                         {
                             // Manager edited a shift.
                             response = await this.shiftController.EditShiftInKronos(shift, user, mappedTeam).ConfigureAwait(false);
-                            return CreateSuccessfulResponse(shift.Id);
                         }
                     }
                 }


### PR DESCRIPTION
We cannot supporting managers drafting open shifts or shift modifications in Teams.

This PR blocks drafting when creating, editing and deleting shifts as well as creating open shifts.

We also now block managers from editing or deleting open shifts in Teams due to api limitations.