### PR TITLE
Block deleting shifts in Teams

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -296,8 +296,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     {
                         if (shift.DraftShift?.IsActive == false || shift.SharedShift?.IsActive == false)
                         {
-                            // Manager deleted a shift.
-                            response = await this.shiftController.DeleteShiftInKronosAsync(shift, user, mappedTeam).ConfigureAwait(false);
+                            // We cannot support delete as we cannot draft delete in Kronos.
+                            response = CreateBadResponse(shift.Id, error: "Deleting shifts in Teams is not supported. Please make your changes in Kronos.");
                         }
                         else
                         {


### PR DESCRIPTION
- Removed delete shift logic
- Remove unused method
- Block manager from deleting shifts in Teams.