### PR TITLE
BugFix: Seconds and miliseconds added to TOR start date time and end date time 

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/Common/XmlHelper.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/Common/XmlHelper.cs
@@ -60,21 +60,24 @@ namespace Microsoft.Teams.App.KronosWfc.BusinessLogic.Common
                 comments.Comment.AddRange(existingNotes);
             }
 
-            comments.Comment.Add(new Comment
+            if (!string.IsNullOrEmpty(noteMessage))
             {
-                CommentText = noteCommentText,
-                Notes = new Notes
+                comments.Comment.Add(new Comment
                 {
-                    Note = new List<Note>
+                    CommentText = noteCommentText,
+                    Notes = new Notes
                     {
-                        new Note
+                        Note = new List<Note>
                         {
-                            Text = noteMessage.Trim(),
-                            Timestamp = timeStamp,
+                            new Note
+                            {
+                                Text = noteMessage.Trim(),
+                                Timestamp = timeStamp,
+                            },
                         },
                     },
-                },
-            });
+                });
+            }
 
             return comments;
         }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/TimeOff/TimeOffActivity.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.App.KronosWfc.BusinessLogic/TimeOff/TimeOffActivity.cs
@@ -217,7 +217,13 @@ namespace Microsoft.Teams.App.KronosWfc.BusinessLogic.TimeOff
         private static TimeOffPeriod CalculateTimeOffPeriod(DateTimeOffset startDateTime, DateTimeOffset endDateTime, string reason)
         {
             string duration;
-            var length = (endDateTime - startDateTime).TotalHours;
+
+            // There is a bug in Teams when creating a TOR on mobile that does not span a full day
+            // where seconds and miliseconds are being added to the start and end time.
+            var modifiedStartDateTime = startDateTime.TimeOfDay.Subtract(new TimeSpan(0, 0, 0, startDateTime.TimeOfDay.Seconds, startDateTime.TimeOfDay.Milliseconds));
+            var modifiedEndDateTime = endDateTime.TimeOfDay.Subtract(new TimeSpan(0, 0, 0, endDateTime.TimeOfDay.Seconds, endDateTime.TimeOfDay.Milliseconds));
+
+            var length = (modifiedEndDateTime - modifiedStartDateTime).TotalHours;
             DateTimeOffset modifiedEndDateTimeForKronos = endDateTime.AddDays(-1);
             if (length % 24 == 0 || length > 24)
             {


### PR DESCRIPTION
- There is a bug in Teams that adds seconds and milliseconds to the start and end time of a time off request when requesting on mobile for a partial day. 
- We now strip this unnecessary part off before creating the request to Kronos
- Also fixed a bug where a TOR could not be created if the sender did not enter a request comment.