### PR TITLE
Update the isActive column automatically

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/UserController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/UserController.cs
@@ -85,16 +85,16 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             {
                 var isUserActive = response.HyperFindResult.Any(h => h.PersonNumber == mappedUser.RowKey);
 
-                // User is either inactive or terminated in Kronos.
-                if (!isUserActive)
+                if (!isUserActive && mappedUser.IsActive)
                 {
+                    // User is either inactive or terminated in Kronos but appears as active in cache.
                     mappedUser.IsActive = false;
                     await this.userMappingProvider.SaveOrUpdateUserMappingEntityAsync(mappedUser).ConfigureAwait(false);
                 }
 
-                // User is active in Kronos but has previosuly been marked as inactive in cache.
                 if (isUserActive && !mappedUser.IsActive)
                 {
+                    // User is active in Kronos but has previosuly been marked as inactive in cache.
                     mappedUser.IsActive = true;
                     await this.userMappingProvider.SaveOrUpdateUserMappingEntityAsync(mappedUser).ConfigureAwait(false);
                 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/UserController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/UserController.cs
@@ -79,16 +79,23 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             }
 
             // Get the mapped user details from user to user mapping table.
-            var mappedUsersResult = await this.userMappingProvider.GetAllActiveMappedUserDetailsAsync().ConfigureAwait(false);
+            var mappedUsersResult = await this.userMappingProvider.GetAllMappedUserDetailsAsync().ConfigureAwait(false);
 
             foreach (var mappedUser in mappedUsersResult)
             {
                 var isUserActive = response.HyperFindResult.Any(h => h.PersonNumber == mappedUser.RowKey);
 
-                if (isUserActive == false)
+                // User is either inactive or terminated in Kronos.
+                if (!isUserActive)
                 {
-                    // User is either inactive or terminated in Kronos
                     mappedUser.IsActive = false;
+                    await this.userMappingProvider.SaveOrUpdateUserMappingEntityAsync(mappedUser).ConfigureAwait(false);
+                }
+
+                // User is active in Kronos but has previosuly been marked as inactive in cache.
+                if (isUserActive && !mappedUser.IsActive)
+                {
+                    mappedUser.IsActive = true;
                     await this.userMappingProvider.SaveOrUpdateUserMappingEntityAsync(mappedUser).ConfigureAwait(false);
                 }
             }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IUserMappingProvider.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IUserMappingProvider.cs
@@ -15,6 +15,12 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
     public interface IUserMappingProvider
     {
         /// <summary>
+        /// Function that will return all of the users that are mapped in Azure Table storage.
+        /// </summary>
+        /// <returns>A list of the mapped Users.</returns>
+        Task<List<AllUserMappingEntity>> GetAllMappedUserDetailsAsync();
+
+        /// <summary>
         /// Function that will return all of the active Users that are mapped in Azure Table storage.
         /// </summary>
         /// <returns>A list of the mapped Users.</returns>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/UserMappingProvider.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/UserMappingProvider.cs
@@ -40,6 +40,31 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
         /// Function that will return all of the Users that are mapped in Azure Table storage.
         /// </summary>
         /// <returns>A list of the mapped Users.</returns>
+        public async Task<List<AllUserMappingEntity>> GetAllMappedUserDetailsAsync()
+        {
+            await this.EnsureInitializedAsync().ConfigureAwait(false);
+
+            // Table query
+            TableQuery<AllUserMappingEntity> query = new TableQuery<AllUserMappingEntity>();
+
+            // Results list
+            List<AllUserMappingEntity> results = new List<AllUserMappingEntity>();
+            TableContinuationToken continuationToken = null;
+            do
+            {
+                TableQuerySegment<AllUserMappingEntity> queryResults = await this.userMappingCloudTable.ExecuteQuerySegmentedAsync(query, continuationToken).ConfigureAwait(false);
+                continuationToken = queryResults.ContinuationToken;
+                results.AddRange(queryResults.Results);
+            }
+            while (continuationToken != null);
+
+            return results;
+        }
+
+        /// <summary>
+        /// Function that will return all of the Users that are mapped in Azure Table storage.
+        /// </summary>
+        /// <returns>A list of the mapped Users.</returns>
         public async Task<List<AllUserMappingEntity>> GetAllActiveMappedUserDetailsAsync()
         {
             await this.EnsureInitializedAsync().ConfigureAwait(false);

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/UserMappingProvider.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/UserMappingProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
         }
 
         /// <summary>
-        /// Function that will return all of the Users that are mapped in Azure Table storage.
+        /// Function that will return all of the users that are mapped in Azure Table storage.
         /// </summary>
         /// <returns>A list of the mapped Users.</returns>
         public async Task<List<AllUserMappingEntity>> GetAllMappedUserDetailsAsync()
@@ -62,7 +62,7 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
         }
 
         /// <summary>
-        /// Function that will return all of the Users that are mapped in Azure Table storage.
+        /// Function that will return all of the active users that are mapped in Azure Table storage.
         /// </summary>
         /// <returns>A list of the mapped Users.</returns>
         public async Task<List<AllUserMappingEntity>> GetAllActiveMappedUserDetailsAsync()


### PR DESCRIPTION
- The connector now automatically updates the isActive property for employees that have been made active.
- This only works for employees that were previously mapped through the configuration app and were made inactive at some point in Kronos. 