### PR TITLE
Ktc/add method to refresh an expired graph token

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/Utility.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/Utility.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
     using Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.TimeOffRequests;
     using Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI;
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models;
+    using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models.Graph;
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers;
     using Newtonsoft.Json;
     using Logon = Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.Logon;
@@ -996,7 +997,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
                 { "CallingMethod", "UpdateTeam" },
             };
 
-            this.GetTenantDetails(out string tenantId, out string clientId, out string clientSecret, out string instance);
+            // Get config details necessary for graph operations from appSettings.
+            setupDetails.GraphConfigurationDetails = this.GetTenantDetails();
 
             // Get configuration info from table.
             var configurationEntity = (await this.configurationProvider.GetConfigurationsAsync().ConfigureAwait(false)).FirstOrDefault();
@@ -1010,17 +1012,16 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
                 setupDetails.ErrorMessage += Resource.KronosURLNotPresent;
             }
 
-            if (!string.IsNullOrEmpty(configurationEntity?.AdminAadObjectId))
+            if (!string.IsNullOrEmpty(configurationEntity.AdminAadObjectId))
             {
                 setupDetails.WFIId = configurationEntity?.WorkforceIntegrationId;
-                var accessToken = this.graphUtility.GetAccessTokenAsync(tenantId, instance, clientId, clientSecret, configurationEntity?.AdminAadObjectId).GetAwaiter().GetResult();
+                setupDetails.GraphConfigurationDetails.ShiftsAdminAadObjectId = configurationEntity?.AdminAadObjectId;
 
-                setupDetails.ShiftsAdminAadObjectId = configurationEntity?.AdminAadObjectId;
+                var accessToken = this.graphUtility.GetAccessTokenAsync(setupDetails.GraphConfigurationDetails).GetAwaiter().GetResult();
 
                 if (!string.IsNullOrEmpty(accessToken))
                 {
-                    setupDetails.ShiftsAccessToken = accessToken;
-                    setupDetails.TenantId = tenantId;
+                    setupDetails.GraphConfigurationDetails.ShiftsAccessToken = accessToken;
                 }
                 else
                 {
@@ -1046,7 +1047,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
 
             setupDetails.IsAllSetUpExists =
                 !string.IsNullOrEmpty(setupDetails.WFIId)
-                && !string.IsNullOrEmpty(setupDetails.ShiftsAccessToken)
+                && !string.IsNullOrEmpty(setupDetails.GraphConfigurationDetails.ShiftsAccessToken)
                 && !string.IsNullOrEmpty(setupDetails.KronosSession)
                 && !string.IsNullOrEmpty(setupDetails.WfmEndPoint)
                 && !string.IsNullOrEmpty(setupDetails.KronosPassword)
@@ -1087,20 +1088,16 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
         /// <summary>
         /// Method to retrieve the necessary details from AppSettings.
         /// </summary>
-        /// <param name="tenantId">The tenant ID.</param>
-        /// <param name="clientId">The client ID.</param>
-        /// <param name="clientSecret">The client secret.</param>
-        /// <param name="instance">The instance URL.</param>
-        private void GetTenantDetails(
-            out string tenantId,
-            out string clientId,
-            out string clientSecret,
-            out string instance)
+        /// <returns>A GraphConfigurationDetails object.</returns>
+        public GraphConfigurationDetails GetTenantDetails()
         {
-            tenantId = this.appSettings.TenantId;
-            clientId = this.appSettings.ClientId;
-            clientSecret = this.appSettings.ClientSecret;
-            instance = this.appSettings.Instance;
+            return new GraphConfigurationDetails
+            {
+                TenantId = this.appSettings.TenantId,
+                ClientId = this.appSettings.ClientId,
+                ClientSecret = this.appSettings.ClientSecret,
+                Instance = this.appSettings.Instance,
+            };
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         private readonly TelemetryClient telemetryClient;
         private readonly IOpenShiftActivity openShiftActivity;
         private readonly Utility utility;
+        private readonly IGraphUtility graphUtility;
         private readonly IOpenShiftMappingEntityProvider openShiftMappingEntityProvider;
         private readonly ITeamDepartmentMappingProvider teamDepartmentMappingProvider;
         private readonly IHttpClientFactory httpClientFactory;
@@ -63,6 +64,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             TelemetryClient telemetryClient,
             IOpenShiftActivity openShiftActivity,
             Utility utility,
+            IGraphUtility graphUtility,
             IOpenShiftMappingEntityProvider openShiftMappingEntityProvider,
             ITeamDepartmentMappingProvider teamDepartmentMappingProvider,
             IHttpClientFactory httpClientFactory,
@@ -78,6 +80,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             this.telemetryClient = telemetryClient;
             this.openShiftActivity = openShiftActivity;
             this.utility = utility;
+            this.graphUtility = graphUtility;
             this.openShiftMappingEntityProvider = openShiftMappingEntityProvider;
             this.teamDepartmentMappingProvider = teamDepartmentMappingProvider;
             this.httpClientFactory = httpClientFactory;
@@ -553,21 +556,20 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         private async Task<GraphOpenShift> GetOpenShiftFromTeams(SetupDetails allRequiredConfigurations, TeamToDepartmentJobMappingEntity mappedOrgJobEntity, AllOpenShiftMappingEntity mappingEntityToDecrement)
         {
             var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfigurations.ShiftsAccessToken);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken);
 
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"teams/{mappedOrgJobEntity.TeamId}/schedule/openShifts/{mappingEntityToDecrement.RowKey}"))
+            var requestUrl = $"teams/{mappedOrgJobEntity.TeamId}/schedule/openShifts/{mappingEntityToDecrement.RowKey}";
+
+            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
             {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
-                {
-                    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    return JsonConvert.DeserializeObject<GraphOpenShift>(responseContent);
-                }
-                else
-                {
-                    this.telemetryClient.TrackTrace($"The open shift with id {mappingEntityToDecrement.RowKey} could not be found in Teams. ");
-                    return null;
-                }
+                var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<GraphOpenShift>(responseContent);
+            }
+            else
+            {
+                this.telemetryClient.TrackTrace($"The open shift with id {mappingEntityToDecrement.RowKey} could not be found in Teams. ");
+                return null;
             }
         }
 
@@ -600,36 +602,33 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     { "SchedulingGroupId", item.SchedulingGroupId },
                 };
 
-                var requestString = JsonConvert.SerializeObject(item);
                 var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfiguration.ShiftsAccessToken);
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfiguration.GraphConfigurationDetails.ShiftsAccessToken);
                 httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", allRequiredConfiguration.WFIId);
 
-                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "teams/" + mappedTeam.TeamId + "/schedule/openShifts")
+                var requestString = JsonConvert.SerializeObject(item);
+                var requestUrl = $"teams/{mappedTeam.TeamId}/schedule/openShifts";
+
+                var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
                 {
-                    Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-                })
+                    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var openShiftResponse = JsonConvert.DeserializeObject<Models.Response.OpenShifts.GraphOpenShift>(responseContent);
+                    var openShiftMappingEntity = this.CreateNewOpenShiftMappingEntity(openShiftResponse, item.KronosUniqueId, monthPartitionKey, mappedTeam?.RowKey);
+
+                    telemetryProps.Add("ResultCode", response.StatusCode.ToString());
+                    telemetryProps.Add("TeamsOpenShiftId", openShiftResponse.Id);
+
+                    this.telemetryClient.TrackTrace(Resource.CreateEntryOpenShiftsEntityMappingAsync, telemetryProps);
+                    await this.openShiftMappingEntityProvider.SaveOrUpdateOpenShiftMappingEntityAsync(openShiftMappingEntity).ConfigureAwait(false);
+
+                    // Add the entity to the found list to prevent later processes from deleting
+                    // the newly added entity.
+                    lookUpEntriesFoundList.Add(openShiftMappingEntity);
+                }
+                else
                 {
-                    var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var openShiftResponse = JsonConvert.DeserializeObject<Models.Response.OpenShifts.GraphOpenShift>(responseContent);
-                        var openShiftMappingEntity = this.CreateNewOpenShiftMappingEntity(openShiftResponse, item.KronosUniqueId, monthPartitionKey, mappedTeam?.RowKey);
-
-                        telemetryProps.Add("ResultCode", response.StatusCode.ToString());
-                        telemetryProps.Add("TeamsOpenShiftId", openShiftResponse.Id);
-
-                        this.telemetryClient.TrackTrace(Resource.CreateEntryOpenShiftsEntityMappingAsync, telemetryProps);
-                        await this.openShiftMappingEntityProvider.SaveOrUpdateOpenShiftMappingEntityAsync(openShiftMappingEntity).ConfigureAwait(false);
-
-                        // Add the entity to the found list to prevent later processes from deleting
-                        // the newly added entity.
-                        lookUpEntriesFoundList.Add(openShiftMappingEntity);
-                    }
-                    else
-                    {
-                        var errorProps = new Dictionary<string, string>()
+                    var errorProps = new Dictionary<string, string>()
                         {
                             { "ResultCode", response.StatusCode.ToString() },
                             { "ResponseHeader", response.Headers.ToString() },
@@ -637,9 +636,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                             { "MappedTeamId", mappedTeam?.TeamId },
                         };
 
-                        // Have the log to capture the 403.
-                        this.telemetryClient.TrackTrace(Resource.CreateEntryOpenShiftsEntityMappingAsync, errorProps);
-                    }
+                    // Have the log to capture the error.
+                    this.telemetryClient.TrackTrace(Resource.CreateEntryOpenShiftsEntityMappingAsync, errorProps);
                 }
             }
 
@@ -655,20 +653,17 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <returns>A unit of execution.</returns>
         private async Task<HttpResponseMessage> UpdateOpenShiftInTeams(SetupDetails allRequiredConfiguration, GraphOpenShift openShift, TeamToDepartmentJobMappingEntity mappedTeam)
         {
-            var requestString = JsonConvert.SerializeObject(openShift);
             var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfiguration.ShiftsAccessToken);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfiguration.GraphConfigurationDetails.ShiftsAccessToken);
             httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", allRequiredConfiguration.WFIId);
 
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "teams/" + mappedTeam.TeamId + "/schedule/openShifts/" + openShift.Id)
+            var requestString = JsonConvert.SerializeObject(openShift);
+            var requestUrl = $"teams/{mappedTeam.TeamId}/schedule/openShifts/{openShift.Id}";
+
+            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Put, requestUrl, requestString).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
             {
-                Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-            })
-            {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
-                {
-                    var successfulUpdateProps = new Dictionary<string, string>()
+                var successfulUpdateProps = new Dictionary<string, string>()
                             {
                                 { "ResponseCode", response.StatusCode.ToString() },
                                 { "ResponseHeader", response.Headers.ToString() },
@@ -676,23 +671,22 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                 { "OpenShiftIdToDelete", openShift.Id },
                             };
 
-                    this.telemetryClient.TrackTrace("Open shift updated.", successfulUpdateProps);
-                }
-                else
-                {
-                    var errorUpdateProps = new Dictionary<string, string>()
-                            {
-                                { "ResponseCode", response.StatusCode.ToString() },
-                                { "ResponseHeader", response.Headers.ToString() },
-                                { "MappedTeamId", mappedTeam?.TeamId },
-                                { "OpenShiftIdToDelete", openShift.Id },
-                            };
-
-                    this.telemetryClient.TrackTrace("Open shift could not be updated.", errorUpdateProps);
-                }
-
-                return response;
+                this.telemetryClient.TrackTrace("Open shift updated.", successfulUpdateProps);
             }
+            else
+            {
+                var errorUpdateProps = new Dictionary<string, string>()
+                            {
+                                { "ResponseCode", response.StatusCode.ToString() },
+                                { "ResponseHeader", response.Headers.ToString() },
+                                { "MappedTeamId", mappedTeam?.TeamId },
+                                { "OpenShiftIdToDelete", openShift.Id },
+                            };
+
+                this.telemetryClient.TrackTrace("Open shift could not be updated.", errorUpdateProps);
+            }
+
+            return response;
         }
 
         /// <summary>
@@ -745,15 +739,15 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         private async Task<HttpResponseMessage> DeleteOpenShiftInTeams(SetupDetails allRequiredConfiguration, AllOpenShiftMappingEntity openShiftMapping, TeamToDepartmentJobMappingEntity mappedTeam)
         {
             var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfiguration.ShiftsAccessToken);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfiguration.GraphConfigurationDetails.ShiftsAccessToken);
             httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", allRequiredConfiguration.WFIId);
 
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, "teams/" + mappedTeam.TeamId + "/schedule/openShifts/" + openShiftMapping.RowKey))
+            var requestUrl = $"teams/{mappedTeam.TeamId}/schedule/openShifts/{openShiftMapping.RowKey}";
+
+            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
             {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
-                {
-                    var successfulDeleteProps = new Dictionary<string, string>()
+                var successfulDeleteProps = new Dictionary<string, string>()
                             {
                                 { "ResponseCode", response.StatusCode.ToString() },
                                 { "ResponseHeader", response.Headers.ToString() },
@@ -761,25 +755,24 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                 { "OpenShiftIdToDelete", openShiftMapping.RowKey },
                             };
 
-                    this.telemetryClient.TrackTrace(Resource.DeleteOrphanDataOpenShiftsEntityMappingAsync, successfulDeleteProps);
+                this.telemetryClient.TrackTrace(Resource.DeleteOrphanDataOpenShiftsEntityMappingAsync, successfulDeleteProps);
 
-                    await this.openShiftMappingEntityProvider.DeleteOrphanDataFromOpenShiftMappingAsync(openShiftMapping).ConfigureAwait(false);
-                }
-                else
-                {
-                    var errorDeleteProps = new Dictionary<string, string>()
-                            {
-                                { "ResponseCode", response.StatusCode.ToString() },
-                                { "ResponseHeader", response.Headers.ToString() },
-                                { "MappedTeamId", mappedTeam?.TeamId },
-                                { "OpenShiftIdToDelete", openShiftMapping.RowKey },
-                            };
-
-                    this.telemetryClient.TrackTrace(Resource.DeleteOrphanDataOpenShiftsEntityMappingAsync, errorDeleteProps);
-                }
-
-                return response;
+                await this.openShiftMappingEntityProvider.DeleteOrphanDataFromOpenShiftMappingAsync(openShiftMapping).ConfigureAwait(false);
             }
+            else
+            {
+                var errorDeleteProps = new Dictionary<string, string>()
+                            {
+                                { "ResponseCode", response.StatusCode.ToString() },
+                                { "ResponseHeader", response.Headers.ToString() },
+                                { "MappedTeamId", mappedTeam?.TeamId },
+                                { "OpenShiftIdToDelete", openShiftMapping.RowKey },
+                            };
+
+                this.telemetryClient.TrackTrace(Resource.DeleteOrphanDataOpenShiftsEntityMappingAsync, errorDeleteProps);
+            }
+
+            return response;
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftController.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var requestUrl = $"teams/{mappedOrgJobEntity.TeamId}/schedule/openShifts/{mappingEntityToDecrement.RowKey}";
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -609,7 +609,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var requestString = JsonConvert.SerializeObject(item);
                 var requestUrl = $"teams/{mappedTeam.TeamId}/schedule/openShifts";
 
-                var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+                var response = await this.graphUtility.SendHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -660,7 +660,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var requestString = JsonConvert.SerializeObject(openShift);
             var requestUrl = $"teams/{mappedTeam.TeamId}/schedule/openShifts/{openShift.Id}";
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Put, requestUrl, requestString).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Put, requestUrl, requestString).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var successfulUpdateProps = new Dictionary<string, string>()
@@ -744,7 +744,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var requestUrl = $"teams/{mappedTeam.TeamId}/schedule/openShifts/{openShiftMapping.RowKey}";
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfiguration.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var successfulDeleteProps = new Dictionary<string, string>()

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftRequestController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/OpenShiftRequestController.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var requestUrl = $"teams/{teamDepartmentMapping.TeamId}/schedule/openShifts/{request.OpenShiftId}";
 
             // Get the open shift entity from Teams as we need the start and end time as well as all the activities.
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -472,7 +472,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var requestUrl = $"teams/{user.ShiftTeamId}/schedule/openShifts/{entityToUpdate.TeamsOpenShiftId}";
 
-            var getOpenShiftResponse = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+            var getOpenShiftResponse = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
             if (getOpenShiftResponse.IsSuccessStatusCode)
             {
                 var getOpenShiftResponseStr = await getOpenShiftResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -508,7 +508,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var approvalRequestUrl = $"teams/{user.ShiftTeamId}/schedule/openshiftchangerequests/{entityToUpdate.RowKey}/approve";
                 var approvalString = JsonConvert.SerializeObject(approvalMessageModel);
 
-                var approvalResponse = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, approvalRequestUrl, approvalString).ConfigureAwait(false);
+                var approvalResponse = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, approvalRequestUrl, approvalString).ConfigureAwait(false);
                 if (approvalResponse.IsSuccessStatusCode)
                 {
                     this.telemetryClient.TrackTrace($"{Resource.ProcessOpenShiftRequestsAsync} ShiftRequestId: {entityToUpdate.RowKey} KronosRequestId: {openShiftRequest.Id}");
@@ -554,7 +554,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var requestUrl = $"teams/{user.ShiftTeamId}/schedule/openshiftchangerequests/{entityToUpdate.RowKey}/decline";
             var requestString = JsonConvert.SerializeObject(declineMessageModel);
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 this.telemetryClient.TrackTrace($"{Resource.ProcessOpenShiftRequestsAsync}- DeclinedShiftRequestId: {entityToUpdate.RowKey}, DeclinedKronosRequestId: {openShiftRequest.Id}");

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -713,7 +713,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var requestUrl = $"teams/{userModelNotFoundList[i].ShiftTeamId}/schedule/shifts";
                 var requestString = JsonConvert.SerializeObject(notFoundShifts[i]);
 
-                var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+                var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -770,7 +770,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                 var requestUrl = $"teams/{user.ShiftTeamId}/schedule/shifts/{item.RowKey}";
 
-                var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
+                var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
                 {
                     var successfulDeleteProps = new Dictionary<string, string>()

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             // We now want to share the schedule between the start and end time of the deleted shift.
             await this.graphUtility.ShareSchedule(
-                            allRequiredConfigurations.ShiftsAccessToken,
+                            allRequiredConfigurations.GraphConfigurationDetails,
                             mappedTeam.TeamId,
                             shift.SharedShift.StartDateTime,
                             shift.SharedShift.EndDateTime,
@@ -706,39 +706,33 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             // create entries from not found list
             for (int i = 0; i < notFoundShifts.Count; i++)
             {
-                var requestString = JsonConvert.SerializeObject(notFoundShifts[i]);
-
                 var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configurationDetails.ShiftsAccessToken);
-                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configurationDetails.GraphConfigurationDetails.ShiftsAccessToken);
                 httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", configurationDetails.WFIId);
 
-                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "teams/" + userModelNotFoundList[i].ShiftTeamId + "/schedule/shifts")
+                var requestUrl = $"teams/{userModelNotFoundList[i].ShiftTeamId}/schedule/shifts";
+                var requestString = JsonConvert.SerializeObject(notFoundShifts[i]);
+
+                var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
                 {
-                    Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-                })
+                    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var shiftResponse = JsonConvert.DeserializeObject<Models.Response.Shifts.Shift>(responseContent);
+                    var shiftId = shiftResponse.Id;
+                    var shiftMappingEntity = this.CreateNewShiftMappingEntity(shiftResponse, notFoundShifts[i].KronosUniqueId, userModelNotFoundList[i]);
+                    await this.shiftMappingEntityProvider.SaveOrUpdateShiftMappingEntityAsync(shiftMappingEntity, shiftId, monthPartitionKey).ConfigureAwait(false);
+                    continue;
+                }
+                else
                 {
-                    var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var shiftResponse = JsonConvert.DeserializeObject<Models.Response.Shifts.Shift>(responseContent);
-                        var shiftId = shiftResponse.Id;
-                        var shiftMappingEntity = this.CreateNewShiftMappingEntity(shiftResponse, notFoundShifts[i].KronosUniqueId, userModelNotFoundList[i]);
-                        await this.shiftMappingEntityProvider.SaveOrUpdateShiftMappingEntityAsync(shiftMappingEntity, shiftId, monthPartitionKey).ConfigureAwait(false);
-                        continue;
-                    }
-                    else
-                    {
-                        var errorProps = new Dictionary<string, string>()
+                    var errorProps = new Dictionary<string, string>()
                         {
                             { "ResultCode", response.StatusCode.ToString() },
                             { "IntegerResult", Convert.ToInt32(response.StatusCode, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture) },
                         };
 
-                        // Have the log to capture the 403.
-                        this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, errorProps);
-                    }
+                    // Have the log to capture the 403.
+                    this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, errorProps);
                 }
             }
         }
@@ -764,39 +758,40 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             foreach (var item in orphanList)
             {
                 var user = userModelList.FirstOrDefault(u => u.KronosPersonNumber == item.KronosPersonNumber);
+
+                if (user == null)
+                {
+                    return;
+                }
+
                 var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configurationDetails.ShiftsAccessToken);
-                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configurationDetails.GraphConfigurationDetails.ShiftsAccessToken);
                 httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", configurationDetails.WFIId);
 
-                if (user != null)
+                var requestUrl = $"teams/{user.ShiftTeamId}/schedule/shifts/{item.RowKey}";
+
+                var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
                 {
-                    using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, $"teams/{user.ShiftTeamId}/schedule/shifts/{item.RowKey}"))
-                    {
-                        var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                        if (response.IsSuccessStatusCode)
-                        {
-                            var successfulDeleteProps = new Dictionary<string, string>()
+                    var successfulDeleteProps = new Dictionary<string, string>()
                             {
                                 { "ResponseCode", response.StatusCode.ToString() },
                                 { "ResponseHeader", response.Headers.ToString() },
                             };
 
-                            this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, successfulDeleteProps);
+                    this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, successfulDeleteProps);
 
-                            await this.shiftMappingEntityProvider.DeleteOrphanDataFromShiftMappingAsync(item).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            var errorDeleteProps = new Dictionary<string, string>()
+                    await this.shiftMappingEntityProvider.DeleteOrphanDataFromShiftMappingAsync(item).ConfigureAwait(false);
+                }
+                else
+                {
+                    var errorDeleteProps = new Dictionary<string, string>()
                             {
                                 { "ResponseCode", response.StatusCode.ToString() },
                                 { "ResponseHeader", response.Headers.ToString() },
                             };
 
-                            this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, errorDeleteProps);
-                        }
-                    }
+                    this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, errorDeleteProps);
                 }
             }
         }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/SwapShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/SwapShiftController.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         private readonly ISwapShiftActivity swapShiftActivity;
         private readonly ISwapShiftMappingEntityProvider swapShiftMappingEntityProvider;
         private readonly Utility utility;
+        private readonly IGraphUtility graphUtility;
         private readonly IHttpClientFactory httpClientFactory;
         private readonly ITeamDepartmentMappingProvider teamDepartmentMappingProvider;
         private readonly IShiftMappingEntityProvider shiftMappingEntityProvider;
@@ -63,6 +64,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <param name="swapShiftActivity">swapshift activity.</param>
         /// <param name="swapShiftMappingEntityProvider">Swap Shift entity provider.</param>
         /// <param name="utility">UniqueId Utility DI.</param>
+        /// <param name="graphUtility">GraphUtility DI.</param>
         /// <param name="httpClientFactory">The HTTP Client DI.</param>
         /// <param name="shiftMappingEntityProvider">Shift mapping entity provider DI.</param>
         /// <param name="teamDepartmentMappingProvider">Team department mapping provider.</param>
@@ -75,6 +77,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             ISwapShiftActivity swapShiftActivity,
             ISwapShiftMappingEntityProvider swapShiftMappingEntityProvider,
             Utility utility,
+            IGraphUtility graphUtility,
             IHttpClientFactory httpClientFactory,
             ITeamDepartmentMappingProvider teamDepartmentMappingProvider,
             IShiftMappingEntityProvider shiftMappingEntityProvider,
@@ -92,6 +95,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             this.swapShiftActivity = swapShiftActivity;
             this.swapShiftMappingEntityProvider = swapShiftMappingEntityProvider;
             this.utility = utility;
+            this.graphUtility = graphUtility;
             this.httpClientFactory = httpClientFactory;
             this.teamDepartmentMappingProvider = teamDepartmentMappingProvider;
             this.shiftMappingEntityProvider = shiftMappingEntityProvider;
@@ -157,8 +161,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                 // Step 1c - Get the sender's shift details.
                 var senderShiftDetails = await this.GetShiftDetailsAsync(
-                    allRequiredConfigurations.ShiftsAccessToken,
-                    allRequiredConfigurations.ShiftsAdminAadObjectId,
+                    allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken,
+                    allRequiredConfigurations.GraphConfigurationDetails.ShiftsAdminAadObjectId,
                     teamsId,
                     swapRequest.SenderShiftId).ConfigureAwait(false);
 
@@ -169,8 +173,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                     // Step 1e - Get the recipient's shift details.
                     var recipientShiftDetails = await this.GetShiftDetailsAsync(
-                        allRequiredConfigurations.ShiftsAccessToken,
-                        allRequiredConfigurations.ShiftsAdminAadObjectId,
+                        allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken,
+                        allRequiredConfigurations.GraphConfigurationDetails.ShiftsAdminAadObjectId,
                         teamsId,
                         swapRequest.RecipientShiftId).ConfigureAwait(false);
 
@@ -421,8 +425,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var recipient = await this.userMappingProvider.GetUserMappingEntityAsyncNew(swapRequest.RecipientUserId, teamsId).ConfigureAwait(false);
 
                 var senderShiftDetails = await this.GetShiftDetailsAsync(
-                        allRequiredConfigurations.ShiftsAccessToken,
-                        allRequiredConfigurations.ShiftsAdminAadObjectId,
+                        allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken,
+                        allRequiredConfigurations.GraphConfigurationDetails.ShiftsAdminAadObjectId,
                         teamsId,
                         swapRequest.SenderShiftId).ConfigureAwait(false);
 
@@ -432,8 +436,8 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     this.telemetryClient.TrackTrace($"{Resource.ApproveOrDeclineSwapShiftRequestToKronosAsync} - Successfully got the shift of {sender?.KronosUserName} - {senderShiftDetails?.Id}", telemetryProps);
 
                     var recipientShiftDetails = await this.GetShiftDetailsAsync(
-                    allRequiredConfigurations.ShiftsAccessToken,
-                    allRequiredConfigurations.ShiftsAdminAadObjectId,
+                    allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken,
+                    allRequiredConfigurations.GraphConfigurationDetails.ShiftsAdminAadObjectId,
                     teamsId,
                     swapRequest.RecipientShiftId).ConfigureAwait(false);
 
@@ -718,7 +722,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                         allRequiredConfigurations.KronosSession,
                         queryDateSpan).ConfigureAwait(false);
 
-                    var graphClient = this.CreateGraphClientWithDelegatedAccess(allRequiredConfigurations.ShiftsAccessToken);
+                    var graphClient = this.CreateGraphClientWithDelegatedAccess(allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken);
 
                     if (swapshiftDetails != null && swapshiftDetails.RequestMgmt?.RequestItems?.SwapShiftRequestItem?.Count > 0)
                     {
@@ -733,11 +737,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                 var notes = approvedData.RequestStatusChanges?.RequestStatusChange;
                                 var note = notes.Select(c => c.Comments).FirstOrDefault()?.Comment?.FirstOrDefault()?.Notes?.Note?.FirstOrDefault().Text;
 
-                                await this.AddSwapShiftApprovalAsync(
-                                    allRequiredConfigurations.ShiftsAccessToken,
-                                    swapShiftEntity,
-                                    note,
-                                    allRequiredConfigurations.WFIId).ConfigureAwait(false);
+                                await this.AddSwapShiftApprovalAsync(allRequiredConfigurations, swapShiftEntity, note).ConfigureAwait(false);
                             }
                         }
                     }
@@ -755,12 +755,11 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                 var note = notes.Select(c => c.Comments).FirstOrDefault()?.Comment?.FirstOrDefault()?.Notes?.Note?.FirstOrDefault().Text;
 
                                 await this.DeclineSwapShiftRequestAsync(
-                                    allRequiredConfigurations?.ShiftsAccessToken,
+                                    allRequiredConfigurations,
                                     swapShiftEntity?.ShiftsTeamId,
                                     swapShiftEntity,
                                     refusedData.StatusName,
-                                    note,
-                                    allRequiredConfigurations.WFIId).ConfigureAwait(false);
+                                    note).ConfigureAwait(false);
                             }
                         }
                     }
@@ -779,12 +778,11 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                                 var note = notes.Select(c => c.Comments).FirstOrDefault()?.Comment?.FirstOrDefault()?.Notes?.Note?.FirstOrDefault().Text;
 
                                 await this.DeclineSwapShiftRequestAsync(
-                                    allRequiredConfigurations?.ShiftsAccessToken,
+                                    allRequiredConfigurations,
                                     swapShiftEntity?.ShiftsTeamId,
                                     swapShiftEntity,
                                     retractedData?.StatusName,
-                                    note,
-                                    allRequiredConfigurations.WFIId).ConfigureAwait(false);
+                                    note).ConfigureAwait(false);
                             }
                         }
                     }
@@ -926,11 +924,10 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <summary>
         /// Method that posts an approved Swap Shift request to Shifts.
         /// </summary>
-        /// <param name="accessToken">The Microsoft Graph access token.</param>
+        /// <param name="allRequiredConfigurations">Configuration details.</param>
         /// <param name="swapShiftMappingEntity">The Swap Shift entity from database.</param>
         /// <param name="note">The necessary notes that are applicable to the Swap Shift request approval.</param>
-        /// <param name="wfIId">The workforce integration id.</param>
-        private async Task AddSwapShiftApprovalAsync(string accessToken, SwapShiftMappingEntity swapShiftMappingEntity, string note, string wfIId)
+        private async Task AddSwapShiftApprovalAsync(SetupDetails allRequiredConfigurations, SwapShiftMappingEntity swapShiftMappingEntity, string note)
         {
             var telemetryProps = new Dictionary<string, string>()
             {
@@ -942,73 +939,68 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} starts at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}", telemetryProps);
 
             var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken);
 
             // Send Passthrough header to indicate the sender of request in outbound call.
-            httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", wfIId);
+            httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", allRequiredConfigurations.WFIId);
 
-            // Approves the swapShift in Shifts.
+            var requestUrl = $"teams/{swapShiftMappingEntity.ShiftsTeamId}/schedule/swapShiftsChangeRequests/{swapShiftMappingEntity.RowKey}/approve";
+
             ApproveMsg approveMsg = new ApproveMsg { Message = note };
             var requestString = JsonConvert.SerializeObject(approveMsg);
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "teams/" + swapShiftMappingEntity.ShiftsTeamId + "/schedule/swapShiftsChangeRequests/" + swapShiftMappingEntity.RowKey + "/approve")
+
+            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
             {
-                Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-            })
-            {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
+                swapShiftMappingEntity.KronosStatus = ApiConstants.ApprovedStatus;
+                swapShiftMappingEntity.ShiftsStatus = ApiConstants.ApprovedStatus;
+
+                await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(true);
+
+                var offeredShift = await this.swapShiftMappingEntityProvider.GetShiftDetailsAsync(swapShiftMappingEntity.TeamsOfferedShiftId).ConfigureAwait(false);
+                var requestedShift = await this.swapShiftMappingEntityProvider.GetShiftDetailsAsync(swapShiftMappingEntity.TeamsRequestedShiftId).ConfigureAwait(false);
+
+                telemetryProps.Add("Delete OfferedShiftId", offeredShift?.RowKey);
+                telemetryProps.Add("Delete RequestedShiftId", requestedShift?.RowKey);
+
+                // Delete the earlier mapping from ShiftMappingEntity for sender as well as for recipient.
+                if (offeredShift != null)
                 {
-                    swapShiftMappingEntity.KronosStatus = ApiConstants.ApprovedStatus;
-                    swapShiftMappingEntity.ShiftsStatus = ApiConstants.ApprovedStatus;
-
-                    await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(true);
-
-                    var offeredShift = await this.swapShiftMappingEntityProvider.GetShiftDetailsAsync(swapShiftMappingEntity.TeamsOfferedShiftId).ConfigureAwait(false);
-                    var requestedShift = await this.swapShiftMappingEntityProvider.GetShiftDetailsAsync(swapShiftMappingEntity.TeamsRequestedShiftId).ConfigureAwait(false);
-
-                    telemetryProps.Add("Delete OfferedShiftId", offeredShift?.RowKey);
-                    telemetryProps.Add("Delete RequestedShiftId", requestedShift?.RowKey);
-
-                    // Delete the earlier mapping from ShiftMappingEntity for sender as well as for recipient.
-                    if (offeredShift != null)
-                    {
-                        await this.shiftMappingEntityProvider.DeleteOrphanDataFromShiftMappingAsync(offeredShift).ConfigureAwait(false);
-                    }
-
-                    if (requestedShift != null)
-                    {
-                        await this.shiftMappingEntityProvider.DeleteOrphanDataFromShiftMappingAsync(requestedShift).ConfigureAwait(false);
-                    }
-
-                    this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} - MS Graph Approval of {swapShiftMappingEntity?.RowKey} has succeeded with status code: {(int)response.StatusCode}", telemetryProps);
-                }
-                else
-                {
-                    swapShiftMappingEntity.KronosStatus = ApiConstants.Declined;
-                    swapShiftMappingEntity.ShiftsStatus = ApiConstants.Declined;
-
-                    telemetryProps.Add("SwapShiftRequestMessage", response?.RequestMessage.ToString());
-                    telemetryProps.Add("SwapShiftReasonPhrase", response.ReasonPhrase);
-
-                    await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(false);
-
-                    this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} - MS Graph Approval of {swapShiftMappingEntity?.RowKey} did not succeed with status code: {(int)response.StatusCode}", telemetryProps);
+                    await this.shiftMappingEntityProvider.DeleteOrphanDataFromShiftMappingAsync(offeredShift).ConfigureAwait(false);
                 }
 
-                this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} ends at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}", telemetryProps);
+                if (requestedShift != null)
+                {
+                    await this.shiftMappingEntityProvider.DeleteOrphanDataFromShiftMappingAsync(requestedShift).ConfigureAwait(false);
+                }
+
+                this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} - MS Graph Approval of {swapShiftMappingEntity?.RowKey} has succeeded with status code: {(int)response.StatusCode}", telemetryProps);
             }
+            else
+            {
+                swapShiftMappingEntity.KronosStatus = ApiConstants.Declined;
+                swapShiftMappingEntity.ShiftsStatus = ApiConstants.Declined;
+
+                telemetryProps.Add("SwapShiftRequestMessage", response?.RequestMessage.ToString());
+                telemetryProps.Add("SwapShiftReasonPhrase", response.ReasonPhrase);
+
+                await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(false);
+
+                this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} - MS Graph Approval of {swapShiftMappingEntity?.RowKey} did not succeed with status code: {(int)response.StatusCode}", telemetryProps);
+            }
+
+            this.telemetryClient.TrackTrace($"{Resource.AddSwapShiftApprovalAsync} ends at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}", telemetryProps);
         }
 
         /// <summary>
         /// Method that will decline a Swap Shift request in Shifts.
         /// </summary>
-        /// <param name="accessToken">The Microsoft Graph access token.</param>
+        /// <param name="allRequiredConfigurations">Configuration details.</param>
         /// <param name="teamsId">The Team ID for which the Swap Shift request is to be declined.</param>
         /// <param name="swapShiftMappingEntity">The Swap Shift entity from database.</param>
         /// <param name="status">The status to post as part of the decline.</param>
         /// <param name="note">Applicable notes for the decline of the Swap Shift request.</param>
-        /// <param name="workforceIntegrationId">The workforce integration id.</param>
-        private async Task DeclineSwapShiftRequestAsync(string accessToken, string teamsId, SwapShiftMappingEntity swapShiftMappingEntity, string status, string note, string workforceIntegrationId)
+        private async Task DeclineSwapShiftRequestAsync(SetupDetails allRequiredConfigurations, string teamsId, SwapShiftMappingEntity swapShiftMappingEntity, string status, string note)
         {
             var telemetryProps = new Dictionary<string, string>()
             {
@@ -1017,36 +1009,32 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             };
 
             this.telemetryClient.TrackTrace($"{Resource.DeclineSwapShiftRequestAsync} starts at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}");
+
             var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", allRequiredConfigurations.GraphConfigurationDetails.ShiftsAccessToken);
 
             // Send Passthrough header to indicate the sender of request in outbound call.
-            httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", workforceIntegrationId);
+            httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", allRequiredConfigurations.WFIId);
 
-            // Declines the swapShift in Shifts.
-            ApproveMsg approveMsg = new ApproveMsg { Message = note };
-            var requestString = JsonConvert.SerializeObject(approveMsg);
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "teams/" + teamsId + "/schedule/swapShiftsChangeRequests/" + swapShiftMappingEntity.RowKey + "/decline")
-            {
-                Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-            })
-            {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+            var requestUrl = $"teams/{teamsId}/schedule/swapShiftsChangeRequests/{swapShiftMappingEntity.RowKey}/decline";
 
-                if (response.IsSuccessStatusCode)
-                {
-                    this.telemetryClient.TrackTrace($"{Resource.DeclineSwapShiftRequestAsync} - MS Graph Decline of {swapShiftMappingEntity?.RowKey} has succeeded with status code: {(int)response.StatusCode}", telemetryProps);
-                    swapShiftMappingEntity.KronosStatus = status;
-                    swapShiftMappingEntity.ShiftsStatus = status;
-                    await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(false);
-                }
-                else
-                {
-                    this.telemetryClient.TrackTrace($"{Resource.DeclineSwapShiftRequestAsync} - MS Graph Decline of {swapShiftMappingEntity?.RowKey} did not succeed with status code: {(int)response.StatusCode}", telemetryProps);
-                    swapShiftMappingEntity.KronosStatus = status;
-                    swapShiftMappingEntity.ShiftsStatus = status;
-                    await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(false);
-                }
+            ApproveMsg declineMsg = new ApproveMsg { Message = note };
+            var requestString = JsonConvert.SerializeObject(declineMsg);
+
+            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                this.telemetryClient.TrackTrace($"{Resource.DeclineSwapShiftRequestAsync} - MS Graph Decline of {swapShiftMappingEntity?.RowKey} has succeeded with status code: {(int)response.StatusCode}", telemetryProps);
+                swapShiftMappingEntity.KronosStatus = status;
+                swapShiftMappingEntity.ShiftsStatus = status;
+                await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(false);
+            }
+            else
+            {
+                this.telemetryClient.TrackTrace($"{Resource.DeclineSwapShiftRequestAsync} - MS Graph Decline of {swapShiftMappingEntity?.RowKey} did not succeed with status code: {(int)response.StatusCode}", telemetryProps);
+                swapShiftMappingEntity.KronosStatus = status;
+                swapShiftMappingEntity.ShiftsStatus = status;
+                await this.swapShiftMappingEntityProvider.AddOrUpdateSwapShiftMappingAsync(swapShiftMappingEntity).ConfigureAwait(false);
             }
 
             this.telemetryClient.TrackTrace($"DeclineSwapShiftRequestAsync ends at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}");

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/SwapShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/SwapShiftController.cs
@@ -887,7 +887,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                 var requestUrl = $"teams/{teamsId}/schedule/shifts/{shiftId}";
 
-                var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+                var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
                 {
                     this.telemetryClient.TrackTrace($"GetShiftDetailsAsync end at {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)}", telemetryProps);
@@ -932,7 +932,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             ApproveMsg approveMsg = new ApproveMsg { Message = note };
             var requestString = JsonConvert.SerializeObject(approveMsg);
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 swapShiftMappingEntity.KronosStatus = ApiConstants.ApprovedStatus;
@@ -1004,7 +1004,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             ApproveMsg declineMsg = new ApproveMsg { Message = note };
             var requestString = JsonConvert.SerializeObject(declineMsg);
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 this.telemetryClient.TrackTrace($"{Resource.DeclineSwapShiftRequestAsync} - MS Graph Decline of {swapShiftMappingEntity?.RowKey} has succeeded with status code: {(int)response.StatusCode}", telemetryProps);

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffController.cs
@@ -748,7 +748,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     var requestUrl = $"teams/{userModelNotFoundList[i].ShiftTeamId}/schedule/timesOff";
                     var requestString = JsonConvert.SerializeObject(timeOff);
 
-                    var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+                    var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
                     if (response.IsSuccessStatusCode)
                     {
                         var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -817,7 +817,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var requestUrl = $"teams/{user[i].ShiftTeamId}/schedule/timeOffRequests/{timeOffLookUpEntriesFoundList[i].ShiftsRequestId}/approve";
                 var requestString = JsonConvert.SerializeObject(timeOffReqCon);
 
-                var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+                var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
                 {
                     TimeOffMappingEntity timeOffMappingEntity = new TimeOffMappingEntity
@@ -870,7 +870,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var requestUrl = $"teams/" + user.ShiftTeamId + "/schedule/timeOffRequests/" + timeOffId + "/decline";
 
-            var response = await this.graphUtility.SendGraphHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 TimeOffMappingEntity timeOffMappingEntity = new TimeOffMappingEntity

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffController.cs
@@ -646,38 +646,6 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         }
 
         /// <summary>
-        /// Method that creates the Microsoft Graph Service client.
-        /// </summary>
-        /// <param name="token">The Graph Access token.</param>
-        /// <returns>A type of <see cref="GraphServiceClient"/> contained in a unit of execution.</returns>
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
-        private async Task<GraphServiceClient> CreateGraphClientWithDelegatedAccessAsync(
-            string token,
-            string workforceIntegrationId)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-        {
-            if (string.IsNullOrEmpty(token))
-            {
-                throw new ArgumentNullException(token);
-            }
-
-            var provider = CultureInfo.InvariantCulture;
-            this.telemetryClient.TrackTrace($"CreateGraphClientWithDelegatedAccessAsync-TimeController called at {DateTime.Now.ToString("o", provider)}");
-
-            var graphClient = new GraphServiceClient(
-            new DelegateAuthenticationProvider(
-                (requestMessage) =>
-                {
-                    requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                    requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    requestMessage.Headers.Add("X-MS-WFMPassthrough", workforceIntegrationId);
-                    return Task.FromResult(0);
-                }));
-            return graphClient;
-        }
-
-        /// <summary>
         /// Method that will calculate the end date accordingly.
         /// </summary>
         /// <param name="requestItem">An object of type <see cref="GlobalTimeOffRequestItem"/>.</param>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffReasonController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffReasonController.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var requestUrl = $"teams/{teamsId}/schedule/timeOffReasons?$search=\"isActive=true\"";
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 string result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -274,7 +274,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             var requestUrl = $"teams/{teamsId}/schedule/timeOffReasons";
             var requestString = JsonConvert.SerializeObject(timeOffReason);
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var createdTimeOffReason = JsonConvert.DeserializeObject<TimeOffReasonResponse.TimeOffReason>(
@@ -303,7 +303,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
             var requestUrl = $"teams/{teamsId}/schedule/timeOffReasons/{timeOffId}";
 
-            var response = await this.graphUtility.SendGraphHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
+            var response = await this.graphUtility.SendHttpRequest(allRequiredConfigurations.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 return true;

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Models/IntegrationAPI/SetupDetails.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Models/IntegrationAPI/SetupDetails.cs
@@ -4,6 +4,8 @@
 
 namespace Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI
 {
+    using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models.Graph;
+
     /// <summary>
     /// This class models the SetupDetails.
     /// </summary>
@@ -25,29 +27,14 @@ namespace Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI
         public string KronosSession { get; set; }
 
         /// <summary>
-        /// Gets or sets the MS Graph Access token.
-        /// </summary>
-        public string ShiftsAccessToken { get; set; }
-
-        /// <summary>
         /// Gets or sets the Kronos API Endpoint.
         /// </summary>
         public string WfmEndPoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the TenantId.
-        /// </summary>
-        public string TenantId { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether or not the prerequisites have been established.
         /// </summary>
         public bool IsAllSetUpExists { get; set; }
-
-        /// <summary>
-        /// Gets or sets the AAD Object Id of the Shifts Admin (Admin using the configurator web app).
-        /// </summary>
-        public string ShiftsAdminAadObjectId { get; set; }
 
         /// <summary>
         /// Gets or sets the Kronos User Name.
@@ -58,5 +45,10 @@ namespace Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI
         /// Gets or sets the Kronos Password.
         /// </summary>
         public string KronosPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets the GraphConfigurationDetails.
+        /// </summary>
+        public GraphConfigurationDetails GraphConfigurationDetails { get; set; }
     }
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Resource.Designer.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Resource.Designer.cs
@@ -596,15 +596,6 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 return ResourceManager.GetString("ProcessCreateOpenShiftRequestFromTeamsAsync", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to ProcessCreateOpenShiftRequestFromTeamsAsync.
-        /// </summary>
-        public static string ProcessCreateOpenShiftRequestFromTeamsAsync {
-            get {
-                return ResourceManager.GetString("ProcessCreateOpenShiftRequestFromTeamsAsync", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to ProcessKronosToShiftsShiftsAsync.

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Startup.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Startup.cs
@@ -171,6 +171,7 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 provider.GetRequiredService<ISwapShiftActivity>(),
                 provider.GetRequiredService<ISwapShiftMappingEntityProvider>(),
                 provider.GetRequiredService<Utility>(),
+                provider.GetRequiredService<IGraphUtility>(),
                 provider.GetRequiredService<IHttpClientFactory>(),
                 provider.GetRequiredService<ITeamDepartmentMappingProvider>(),
                 provider.GetRequiredService<IShiftMappingEntityProvider>(),
@@ -196,7 +197,8 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 provider.GetRequiredService<AppSettings>(),
                 provider.GetRequiredService<IHttpClientFactory>(),
                 provider.GetRequiredService<ITeamDepartmentMappingProvider>(),
-                provider.GetRequiredService<Utility>()));
+                provider.GetRequiredService<Utility>(),
+                provider.GetRequiredService<IGraphUtility>()));
 
             services.AddSingleton((provider) => new ShiftController(
                 provider.GetRequiredService<IUserMappingProvider>(),
@@ -270,6 +272,7 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 provider.GetRequiredService<TelemetryClient>(),
                 provider.GetRequiredService<IOpenShiftActivity>(),
                 provider.GetRequiredService<Utility>(),
+                provider.GetRequiredService<IGraphUtility>(),
                 provider.GetRequiredService<IOpenShiftMappingEntityProvider>(),
                 provider.GetRequiredService<ITeamDepartmentMappingProvider>(),
                 provider.GetRequiredService<IHttpClientFactory>(),
@@ -287,6 +290,7 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 provider.GetRequiredService<IHttpClientFactory>(),
                 provider.GetRequiredService<IOpenShiftMappingEntityProvider>(),
                 provider.GetRequiredService<Utility>(),
+                provider.GetRequiredService<IGraphUtility>(),
                 provider.GetRequiredService<IShiftMappingEntityProvider>()));
 
             services.AddSingleton((provider) => new TimeOffController(
@@ -298,6 +302,7 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 provider.GetRequiredService<IAzureTableStorageHelper>(),
                 provider.GetRequiredService<ITimeOffMappingEntityProvider>(),
                 provider.GetRequiredService<Utility>(),
+                provider.GetRequiredService<IGraphUtility>(),
                 provider.GetRequiredService<ITeamDepartmentMappingProvider>(),
                 provider.GetRequiredService<IHttpClientFactory>(),
                 provider.GetRequiredService<BackgroundTaskWrapper>()));
@@ -361,7 +366,6 @@ namespace Microsoft.Teams.Shifts.Integration.API
                HttpStatusCode.InternalServerError, // 500
                HttpStatusCode.BadGateway, // 502
                HttpStatusCode.GatewayTimeout, // 504
-               HttpStatusCode.Forbidden, // 403
             };
 
             return HttpPolicyExtensions

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Microsoft.Teams.Shifts.Integration.BusinessLogic.csproj
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Microsoft.Teams.Shifts.Integration.BusinessLogic.csproj
@@ -287,6 +287,7 @@
     <Compile Include="Models\ConfigEntityViewModel.cs" />
     <Compile Include="Models\ConfigurationEntity.cs" />
     <Compile Include="Models\Encryption.cs" />
+    <Compile Include="Models\Graph\GraphConfigurationDetails.cs" />
     <Compile Include="Models\KronosDetails.cs" />
     <Compile Include="Models\RequestModels\ShareSchedule.cs" />
     <Compile Include="Models\ResponseModels\ResponseError.cs" />

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Models/Graph/GraphConfigurationDetails.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Models/Graph/GraphConfigurationDetails.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="GraphConfigurationDetails.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Models.Graph
+{
+    /// <summary>
+    /// Contains all the necessary configuration details to enable Graph requests.
+    /// </summary>
+    public class GraphConfigurationDetails
+    {
+        /// <summary>
+        /// Gets or sets the TenantId.
+        /// </summary>
+        public string TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ClientId.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ClientSecret.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Instance.
+        /// </summary>
+        public string Instance { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AAD Object Id of the Shifts Admin.
+        /// </summary>
+        public string ShiftsAdminAadObjectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MS Graph Access token.
+        /// </summary>
+        public string ShiftsAccessToken { get; set; }
+    }
+}

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/GraphUtility.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/GraphUtility.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
     using Microsoft.Teams.Shifts.Integration.API.Models.Request;
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Cache;
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models;
+    using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models.Graph;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -47,40 +48,23 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             this.httpClientFactory = httpClientFactory;
         }
 
-        /// <summary>
-        /// Method to call the Graph API to register the workforce integration.
-        /// </summary>
-        /// <param name="workforceIntegration">The workforce integration.</param>
-        /// <param name="accessToken">The access token.</param>
-        /// <returns>The JSON response of the Workforce Integration registration.</returns>
-        public async Task<HttpResponseMessage> RegisterWorkforceIntegrationAsync(
-            Models.RequestModels.WorkforceIntegration workforceIntegration,
-            string accessToken)
+        /// <inheritdoc/>
+        public async Task<HttpResponseMessage> RegisterWorkforceIntegrationAsync(Models.RequestModels.WorkforceIntegration workforceIntegration, GraphConfigurationDetails graphConfigurationDetails)
         {
             var provider = CultureInfo.InvariantCulture;
             this.telemetryClient.TrackTrace(BusinessLogicResource.RegisterWorkforceIntegrationAsync + " called at " + DateTime.Now.ToString("o", provider));
 
+            var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
+
+            var requestUrl = "teamwork/workforceIntegrations";
             var requestString = JsonConvert.SerializeObject(workforceIntegration);
-            var httpClientWFI = this.httpClientFactory.CreateClient("GraphBetaAPI");
-            httpClientWFI.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            httpClientWFI.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "teamwork/workforceIntegrations")
-            {
-                Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-            })
-            {
-                var response = await httpClientWFI.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                return response;
-            }
+
+            return await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Fetch user details for shifts using graph api tokens.
-        /// </summary>
-        /// <param name="accessToken">Access Token.</param>
-        /// <returns>The shift user.</returns>
-        public async Task<List<ShiftUser>> FetchShiftUserDetailsAsync(
-            string accessToken)
+        /// <inheritdoc/>
+        public async Task<List<ShiftUser>> FetchShiftUserDetailsAsync(GraphConfigurationDetails graphConfigurationDetails)
         {
             var fetchShiftUserDetailsProps = new Dictionary<string, string>()
             {
@@ -93,40 +77,38 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             bool hasMoreUsers = false;
 
             var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            var requestUri = "users";
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
+
+            var requestUrl = "users";
+
             do
             {
-                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+                var response = await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
                 {
-                    var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-                        var jsonResult = JsonConvert.DeserializeObject<ShiftUserModel>(responseContent);
-                        shiftUsers.AddRange(jsonResult.Value);
-                        if (jsonResult.NextLink != null)
-                        {
-                            hasMoreUsers = true;
-                            requestUri = jsonResult.NextLink.ToString();
-                        }
-                        else
-                        {
-                            hasMoreUsers = false;
-                        }
+                    var jsonResult = JsonConvert.DeserializeObject<ShiftUserModel>(responseContent);
+                    shiftUsers.AddRange(jsonResult.Value);
+                    if (jsonResult.NextLink != null)
+                    {
+                        hasMoreUsers = true;
+                        requestUrl = jsonResult.NextLink.ToString();
                     }
                     else
                     {
-                        var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var failedResponseProps = new Dictionary<string, string>()
+                        hasMoreUsers = false;
+                    }
+                }
+                else
+                {
+                    var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var failedResponseProps = new Dictionary<string, string>()
                         {
                             { "FailedResponse", failedResponseContent },
                         };
 
-                        this.telemetryClient.TrackTrace(BusinessLogicResource.FetchShiftUserDetailsAsync, failedResponseProps);
-                    }
+                    this.telemetryClient.TrackTrace(BusinessLogicResource.FetchShiftUserDetailsAsync, failedResponseProps);
                 }
             }
             while (hasMoreUsers == true);
@@ -134,16 +116,8 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             return shiftUsers;
         }
 
-        /// <summary>
-        /// Share the schedule between the given dates.
-        /// </summary>
-        /// <param name="accessToken">Access Token.</param>
-        /// <param name="teamId">The id of the team which schedule we want to share.</param>
-        /// <param name="startDateTime">The start time to share the schedule from.</param>
-        /// <param name="endDateTime">the end time to share the schedule to.</param>
-        /// <param name="notifyTeam">Whether to notify the team or not.</param>
-        /// <returns>Http response message.</returns>
-        public async Task<HttpResponseMessage> ShareSchedule(string accessToken, string teamId, DateTime startDateTime, DateTime endDateTime, bool notifyTeam)
+        /// <inheritdoc/>
+        public async Task<HttpResponseMessage> ShareSchedule(GraphConfigurationDetails graphConfigurationDetails, string teamId, DateTime startDateTime, DateTime endDateTime, bool notifyTeam)
         {
             var shareRequest = new ShareSchedule
             {
@@ -152,29 +126,18 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
                 EndDateTime = endDateTime,
             };
 
-            var requestString = JsonConvert.SerializeObject(shareRequest);
-
             var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, $"teams/{teamId}/schedule/share")
-            {
-                Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-            })
-            {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                return response;
-            }
+            var requestUrl = $"teams/{teamId}/schedule/share";
+            var requestString = JsonConvert.SerializeObject(shareRequest);
+
+            return await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Post, requestUrl, requestString).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Fetch user details for shifts using graph api tokens.
-        /// </summary>
-        /// <param name="accessToken">Access Token.</param>
-        /// <returns>The shift user.</returns>
-        public async Task<List<ShiftTeams>> FetchShiftTeamDetailsAsync(
-            string accessToken)
+        /// <inheritdoc/>
+        public async Task<List<ShiftTeams>> FetchShiftTeamDetailsAsync(GraphConfigurationDetails graphConfigurationDetails)
         {
             var fetchShiftUserDetailsProps = new Dictionary<string, string>()
             {
@@ -185,49 +148,47 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             var hasMoreTeams = false;
 
             this.telemetryClient.TrackTrace(BusinessLogicResource.FetchShiftTeamDetailsAsync, fetchShiftUserDetailsProps);
-            var hcfClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
-            hcfClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            hcfClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
 
             // Filter group who has associated teams also.
-            var requestUri = "groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')";
+            var requestUrl = "groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')";
+
             do
             {
-                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+                var response = await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
                 {
-                    var response = await hcfClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                    if (response.IsSuccessStatusCode)
+                    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var allResponse = JsonConvert.DeserializeObject<AllShiftsTeam>(responseContent);
+                    shiftTeams.AddRange(allResponse.ShiftTeams);
+
+                    // If Shifts has more Teams. Typically graph API has 100 teams in one batch.
+                    // Using nextlink, teams from next batch is fetched.
+                    if (allResponse.NextLink != null)
                     {
-                        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var allResponse = JsonConvert.DeserializeObject<AllShiftsTeam>(responseContent);
-                        shiftTeams.AddRange(allResponse.ShiftTeams);
-
-                        // If Shifts has more Teams. Typically graph API has 100 teams in one batch.
-                        // Using nextlink, teams from next batch is fetched.
-                        if (allResponse.NextLink != null)
-                        {
-                            requestUri = allResponse.NextLink.ToString();
-                            hasMoreTeams = true;
-                        }
-
-                        // nextlink is null when there are no batch of teams to be fetched.
-                        else
-                        {
-                            hasMoreTeams = false;
-                        }
+                        requestUrl = allResponse.NextLink.ToString();
+                        hasMoreTeams = true;
                     }
+
+                    // nextlink is null when there are no batch of teams to be fetched.
                     else
                     {
                         hasMoreTeams = false;
+                    }
+                }
+                else
+                {
+                    hasMoreTeams = false;
 
-                        var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var failedResponseProps = new Dictionary<string, string>()
+                    var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var failedResponseProps = new Dictionary<string, string>()
                         {
                             { "FailedResponse", failedResponseContent },
                         };
 
-                        this.telemetryClient.TrackTrace(BusinessLogicResource.FetchShiftTeamDetailsAsync, failedResponseProps);
-                    }
+                    this.telemetryClient.TrackTrace(BusinessLogicResource.FetchShiftTeamDetailsAsync, failedResponseProps);
                 }
             }
 
@@ -237,34 +198,56 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             return shiftTeams;
         }
 
-        /// <summary>
-        /// Method that will obtain the Graph token.
-        /// </summary>
-        /// <param name="tenantId">The Tenant ID.</param>
-        /// <param name="instance">The instance.</param>
-        /// <param name="clientId">The App ID of the Web Application.</param>
-        /// <param name="clientSecret">The client secret.</param>
-        /// <param name="userId">The AAD Object ID of the Admin, could also be the UPN.</param>
-        /// <returns>A string that represents the Microsoft Graph API token.</returns>
-        public async Task<string> GetAccessTokenAsync(
-            string tenantId,
-            string instance,
-            string clientId,
-            string clientSecret,
-            string userId = default(string))
+        /// <inheritdoc/>
+        public async Task<HttpResponseMessage> SendGraphHttpRequest(GraphConfigurationDetails graphConfigurationDetails, HttpClient httpClient, HttpMethod httpMethod, string requestUrl, string requestString = null)
         {
-            string authority = $"{instance}{tenantId}";
-            var cache = new RedisTokenCache(this.cache, clientId);
+            using (var httpRequestMessage = new HttpRequestMessage(httpMethod, requestUrl))
+            {
+                if (!string.IsNullOrEmpty(requestString))
+                {
+                    httpRequestMessage.Content = new StringContent(requestString, Encoding.UTF8, "application/json");
+                }
+
+                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    // Refresh the access token and recall
+                    var newToken = await this.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
+
+                    graphConfigurationDetails.ShiftsAccessToken = newToken;
+
+                    using (var retryRequestMessage = new HttpRequestMessage(httpMethod, requestUrl))
+                    {
+                        if (!string.IsNullOrEmpty(requestString))
+                        {
+                            retryRequestMessage.Content = new StringContent(requestString, Encoding.UTF8, "application/json");
+                        }
+
+                        retryRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", newToken);
+                        return await httpClient.SendAsync(retryRequestMessage).ConfigureAwait(false);
+                    }
+                }
+
+                return response;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GetAccessTokenAsync(GraphConfigurationDetails graphConfigurationDetails)
+        {
+            string authority = $"{graphConfigurationDetails.Instance}{graphConfigurationDetails.TenantId}";
+            var cache = new RedisTokenCache(this.cache, graphConfigurationDetails.ClientId);
             var authContext = new AuthenticationContext(authority, cache);
-            var userIdentity = new UserIdentifier(userId, UserIdentifierType.UniqueId);
+            var userIdentity = new UserIdentifier(graphConfigurationDetails.ShiftsAdminAadObjectId, UserIdentifierType.UniqueId);
 
             try
             {
                 var result = await authContext.AcquireTokenSilentAsync(
                     "https://graph.microsoft.com",
                     new ClientCredential(
-                        clientId,
-                        clientSecret),
+                        graphConfigurationDetails.ClientId,
+                        graphConfigurationDetails.ClientSecret),
                     userIdentity).ConfigureAwait(false);
                 return result.AccessToken;
             }
@@ -274,21 +257,14 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
                 var retryResult = await authContext.AcquireTokenAsync(
                     "https://graph.microsoft.com",
                     new ClientCredential(
-                        clientId,
-                        clientSecret)).ConfigureAwait(false);
+                        graphConfigurationDetails.ClientId,
+                        graphConfigurationDetails.ClientSecret)).ConfigureAwait(false);
                 return retryResult.AccessToken;
             }
         }
 
-        /// <summary>
-        /// Method that will delete the workforce integration from MS Graph.
-        /// </summary>
-        /// <param name="workforceIntegrationId">The workforce integration ID to delete.</param>
-        /// <param name="accessToken">The access token.</param>
-        /// <returns>A unit of execution that contains the response.</returns>
-        public async Task<string> DeleteWorkforceIntegrationAsync(
-            string workforceIntegrationId,
-            string accessToken)
+        /// <inheritdoc/>
+        public async Task<string> DeleteWorkforceIntegrationAsync(string workforceIntegrationId, GraphConfigurationDetails graphConfigurationDetails)
         {
             var wfiDeletionProps = new Dictionary<string, string>()
             {
@@ -299,41 +275,31 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, wfiDeletionProps);
 
             var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, $"teamwork/workforceIntegrations/{workforceIntegrationId}")
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
+
+            var requestUrl = $"teamwork/workforceIntegrations/{workforceIntegrationId}";
+
+            var response = await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
             {
-            })
+                return response.StatusCode.ToString();
+            }
+            else
             {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
-                {
-                    return response.StatusCode.ToString();
-                }
-                else
-                {
-                    var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var failedResponseProps = new Dictionary<string, string>()
+                var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var failedResponseProps = new Dictionary<string, string>()
                     {
                         { "FailedResponse", failedResponseContent },
                         { "WorkForceIntegrationId", workforceIntegrationId },
                     };
 
-                    this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, failedResponseProps);
-                    return string.Empty;
-                }
+                this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, failedResponseProps);
+                return string.Empty;
             }
         }
 
-        /// <summary>
-        /// Method that fetchs the scheduling group details based on the shift teams Id provided.
-        /// </summary>
-        /// <param name="accessToken">Access Token.</param>
-        /// <param name="shiftTeamId">Shift Team Id.</param>
-        /// <returns>Shift scheduling group details.</returns>
-        public async Task<string> FetchSchedulingGroupDetailsAsync(
-            string accessToken,
-            string shiftTeamId)
+        /// <inheritdoc/>
+        public async Task<string> FetchSchedulingGroupDetailsAsync(GraphConfigurationDetails graphConfigurationDetails, string shiftTeamId)
         {
             var fetchShiftUserDetailsProps = new Dictionary<string, string>()
             {
@@ -342,97 +308,84 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
             };
 
             this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, fetchShiftUserDetailsProps);
-            var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
 
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "teams/" + shiftTeamId + "/schedule/schedulingGroups")
+            var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
+
+            var requestUrl = $"teams/{shiftTeamId}/schedule/schedulingGroups";
+
+            var response = await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Get, requestUrl).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
             {
-                Headers =
-                    {
-                        { HttpRequestHeader.Authorization.ToString(), $"Bearer {accessToken}" },
-                    },
-            })
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            else
             {
-                var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode)
-                {
-                    var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    return responseContent;
-                }
-                else
-                {
-                    var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var failedResponseProps = new Dictionary<string, string>()
+                var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var failedResponseProps = new Dictionary<string, string>()
                         {
                             { "FailedResponse", failedResponseContent },
                             { "ShiftTeamId", shiftTeamId },
                         };
 
-                    this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, failedResponseProps);
-                    return string.Empty;
-                }
+                this.telemetryClient.TrackTrace(MethodBase.GetCurrentMethod().Name, failedResponseProps);
+                return string.Empty;
             }
         }
 
-        /// <summary>
-        /// Method to update the Workforce Integration ID to the schedule.
-        /// </summary>
-        /// <param name="teamsId">The Shift team Id.</param>
-        /// <param name="graphClient">The Graph Client.</param>
-        /// <param name="wfIID">The Workforce Integration Id.</param>
-        /// <param name="accessToken">The MS Graph Access token.</param>
-        /// <returns>A unit of execution that contains the success or failure Response.</returns>
-        public async Task<bool> AddWFInScheduleAsync(
-            string teamsId,
-            GraphServiceClient graphClient,
-            string wfIID,
-            string accessToken)
+        /// <inheritdoc/>
+        public async Task<bool> AddWFInScheduleAsync(string teamsId, string wfIID, GraphConfigurationDetails graphConfigurationDetails)
         {
-            if (graphClient is null)
-            {
-                throw new ArgumentNullException(nameof(graphClient));
-            }
-
             try
             {
-                var sched = await graphClient.Teams[teamsId].Schedule
-                            .Request()
-                            .GetAsync().ConfigureAwait(false);
+                var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
+
+                var scheduleRequestUrl = $"teams/{teamsId}/schedule";
+
+                var getScheduleResponse = await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Get, scheduleRequestUrl).ConfigureAwait(false);
+                if (!getScheduleResponse.IsSuccessStatusCode)
+                {
+                    var failedScheduleResponseContent = await getScheduleResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var failedResponseProps = new Dictionary<string, string>()
+                        {
+                            { "FailedResponse", failedScheduleResponseContent },
+                        };
+
+                    this.telemetryClient.TrackTrace($"{BusinessLogicResource.AddWorkForceIntegrationToSchedule} - Failed to retrieve schedule.", failedResponseProps);
+                    return false;
+                }
+
+                var scheduleResponseContent = await getScheduleResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var scheduleResponse = JsonConvert.DeserializeObject<Schedule>(scheduleResponseContent);
 
                 var schedule = new Schedule
                 {
                     Enabled = true,
-                    TimeZone = sched.TimeZone,
+                    TimeZone = scheduleResponse.TimeZone,
                     WorkforceIntegrationIds = new List<string>() { wfIID },
                 };
 
-                var requestString = JsonConvert.SerializeObject(schedule);
-                var httpClient = this.httpClientFactory.CreateClient("GraphBetaAPI");
-                using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "teams/" + teamsId + "/schedule")
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", graphConfigurationDetails.ShiftsAccessToken);
+
+                var addWfiRequestUrl = $"teams/{teamsId}/schedule";
+                var addWfiRequestString = JsonConvert.SerializeObject(schedule);
+
+                var addWfiResponse = await this.SendGraphHttpRequest(graphConfigurationDetails, httpClient, HttpMethod.Put, addWfiRequestUrl, addWfiRequestString).ConfigureAwait(false);
+                if (addWfiResponse.IsSuccessStatusCode)
                 {
-                    Headers =
-                    {
-                        { HttpRequestHeader.Authorization.ToString(), $"Bearer {accessToken}" },
-                    },
-                    Content = new StringContent(requestString, Encoding.UTF8, "application/json"),
-                })
+                    return true;
+                }
+                else
                 {
-                    var response = await httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        return true;
-                    }
-                    else
-                    {
-                        var failedResponseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var failedResponseProps = new Dictionary<string, string>()
+                    var failedResponseContent = await addWfiResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var failedResponseProps = new Dictionary<string, string>()
                         {
                             { "FailedResponse", failedResponseContent },
                         };
 
-                        this.telemetryClient.TrackTrace(BusinessLogicResource.AddWorkForceIntegrationToSchedule, failedResponseProps);
-                        return false;
-                    }
+                    this.telemetryClient.TrackTrace($"{BusinessLogicResource.AddWorkForceIntegrationToSchedule} - Failed to add WFI Id to schedule.", failedResponseProps);
+                    return false;
                 }
             }
             catch (Exception ex)

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IGraphUtility.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IGraphUtility.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.Graph;
     using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models;
+    using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models.Graph;
 
     /// <summary>
     /// This interface will contain the necessary methods to interface with Microsoft Graph.
@@ -20,83 +20,76 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
         /// This method will make the call to Microsoft Graph to be able to register the workforce integration.
         /// </summary>
         /// <param name="workforceIntegration">The data to register the workforce integration.</param>
-        /// <param name="accessToken">The MS Graph API token.</param>
+        /// <param name="graphConfigurationDetails">The Graph configuration details.</param>
         /// <returns>A string that contains the necessary response.</returns>
-        Task<HttpResponseMessage> RegisterWorkforceIntegrationAsync(
-            Models.RequestModels.WorkforceIntegration workforceIntegration,
-            string accessToken);
+        Task<HttpResponseMessage> RegisterWorkforceIntegrationAsync(Models.RequestModels.WorkforceIntegration workforceIntegration, GraphConfigurationDetails graphConfigurationDetails);
 
         /// <summary>
         /// Fetch user details for shifts using graph api tokens.
         /// </summary>
-        /// <param name="accessToken">Access Token.</param>
+        /// <param name="graphConfigurationDetails">Graph configuration details.</param>
         /// <returns>The shift user.</returns>
-        Task<List<ShiftUser>> FetchShiftUserDetailsAsync(
-            string accessToken);
+        Task<List<ShiftUser>> FetchShiftUserDetailsAsync(GraphConfigurationDetails graphConfigurationDetails);
 
         /// <summary>
         /// Share the schedule between the given date range.
         /// </summary>
-        /// <param name="accessToken">The MS GraphAPI token.</param>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
         /// <param name="teamId">The id of the team whos schedule we want to share.</param>
         /// <param name="startDateTime">The start time we want to share from.</param>
         /// <param name="endDateTime">The end time we want to share until.</param>
         /// <param name="notifyTeam">Whether we want to notify the team or not.</param>
         /// <returns>Http response message.</returns>
-        Task<HttpResponseMessage> ShareSchedule(string accessToken, string teamId, DateTime startDateTime, DateTime endDateTime, bool notifyTeam);
+        Task<HttpResponseMessage> ShareSchedule(GraphConfigurationDetails graphConfigurationDetails, string teamId, DateTime startDateTime, DateTime endDateTime, bool notifyTeam);
 
         /// <summary>
         /// Fetch user details for shifts using graph api tokens.
         /// </summary>
-        /// <param name="accessToken">Access Token.</param>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
         /// <returns>The shift user.</returns>
-        Task<List<ShiftTeams>> FetchShiftTeamDetailsAsync(
-            string accessToken);
+        Task<List<ShiftTeams>> FetchShiftTeamDetailsAsync(GraphConfigurationDetails graphConfigurationDetails);
+
+        /// <summary>
+        /// Sends a graph request.
+        /// </summary>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
+        /// <param name="httpClient">The http client.</param>
+        /// <param name="httpMethod">The http method.</param>
+        /// <param name="requestUrl">The request URI.</param>
+        /// <param name="requestString">The request string to add as the request content.</param>
+        /// <returns>A HttpResponseMessage object.</returns>
+        Task<HttpResponseMessage> SendGraphHttpRequest(GraphConfigurationDetails graphConfigurationDetails, HttpClient httpClient, HttpMethod httpMethod, string requestUrl, string requestString = null);
 
         /// <summary>
         /// Method that will get the Microsoft Graph token.
         /// </summary>
-        /// <param name="tenantId">The Tenant ID.</param>
-        /// <param name="instance">The instance.</param>
-        /// <param name="clientId">The App ID of the Configuration Web App.</param>
-        /// <param name="clientSecret">The Client Secret.</param>
-        /// <param name="userId">The user ID.</param>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
         /// <returns>The string that represents the Microsoft Graph token.</returns>
-        Task<string> GetAccessTokenAsync(
-            string tenantId,
-            string instance,
-            string clientId,
-            string clientSecret,
-            string userId = default(string));
+        Task<string> GetAccessTokenAsync(GraphConfigurationDetails graphConfigurationDetails);
 
         /// <summary>
         /// Method that will remove the WorkforceIntegrationId from MS Graph.
         /// </summary>
         /// <param name="workforceIntegrationId">The Workforce Integration ID to delete.</param>
-        /// <param name="accessToken">The graph access token.</param>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
         /// <returns>A unit of exection that represents the response.</returns>
-        Task<string> DeleteWorkforceIntegrationAsync(
-            string workforceIntegrationId,
-            string accessToken);
+        Task<string> DeleteWorkforceIntegrationAsync(string workforceIntegrationId, GraphConfigurationDetails graphConfigurationDetails);
 
         /// <summary>
         /// Method that fetchs the scheduling group details based on the shift teams Id provided.
         /// </summary>
-        /// <param name="accessToken">The graph access token.</param>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
         /// <param name="shiftTeamId">The Shift team Id.</param>
         /// <returns>Shift scheduling group details.</returns>
-        Task<string> FetchSchedulingGroupDetailsAsync(
-           string accessToken,
-           string shiftTeamId);
+        Task<string> FetchSchedulingGroupDetailsAsync(GraphConfigurationDetails graphConfigurationDetails, string shiftTeamId);
 
         /// <summary>
         /// Method that fetchs the scheduling group details based on the shift teams Id provided.
         /// </summary>
         /// <param name="teamsId">The Shift team Id.</param>
-        /// <param name="graphClient">The Graph Client.</param>
         /// <param name="wfIID">The Workforce Integration Id.</param>
-        /// <param name="accessToken">The MS Graph Access token.</param>
+        /// <param name="graphConfigurationDetails">The graph configuration details.</param>
         /// <returns>A unit of execution that contains the success or failure Response.</returns>
-        Task<bool> AddWFInScheduleAsync(string teamsId, GraphServiceClient graphClient, string wfIID, string accessToken);
+        Task<bool> AddWFInScheduleAsync(string teamsId, string wfIID, GraphConfigurationDetails graphConfigurationDetails);
     }
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IGraphUtility.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Providers/IGraphUtility.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers
         /// <param name="requestUrl">The request URI.</param>
         /// <param name="requestString">The request string to add as the request content.</param>
         /// <returns>A HttpResponseMessage object.</returns>
-        Task<HttpResponseMessage> SendGraphHttpRequest(GraphConfigurationDetails graphConfigurationDetails, HttpClient httpClient, HttpMethod httpMethod, string requestUrl, string requestString = null);
+        Task<HttpResponseMessage> SendHttpRequest(GraphConfigurationDetails graphConfigurationDetails, HttpClient httpClient, HttpMethod httpMethod, string requestUrl, string requestString = null);
 
         /// <summary>
         /// Method that will get the Microsoft Graph token.

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/HomeController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/HomeController.cs
@@ -262,12 +262,17 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
                 var graphConfigurationDetails = this.utility.GetTenantDetails();
                 graphConfigurationDetails.ShiftsAdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
 
-                var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
+                graphConfigurationDetails.ShiftsAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
+
+                configurationEntity.WorkforceIntegrationSecret = workforceIntegrationRequest.Encryption.Secret;
+                configurationEntity.AdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
+
+                await this.configurationProvider.SaveOrUpdateConfigurationAsync(configurationEntity).ConfigureAwait(false);
 
                 // Call the Graph API to register the workforce integration
                 var workforceIntegrationResponse = await this.graphUtility.RegisterWorkforceIntegrationAsync(
                     workforceIntegrationRequest,
-                    graphAccessToken).ConfigureAwait(false);
+                    graphConfigurationDetails).ConfigureAwait(false);
 
                 if (workforceIntegrationResponse.IsSuccessStatusCode)
                 {

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/HomeController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/HomeController.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
     {
         private readonly IConfigurationProvider configurationProvider;
         private readonly TelemetryClient telemetryClient;
+        private readonly Utility utility;
         private readonly IGraphUtility graphUtility;
         private readonly ILogonActivity logonActivity;
         private readonly AppSettings appSettings;
@@ -43,6 +44,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         /// </summary>
         /// <param name="configurationProvider">configurationProvider DI.</param>
         /// <param name="telemetryClient">The logging mechanism through Application Insights.</param>
+        /// <param name="utility">Utility DI.</param>
         /// <param name="graphUtility">Having the ability to DI the mechanism to get the token from MS Graph.</param>
         /// <param name="logonActivity">Logon activity.</param>
         /// <param name="appSettings">app settings.</param>
@@ -50,6 +52,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         public HomeController(
             BusinessLogic.Providers.IConfigurationProvider configurationProvider,
             TelemetryClient telemetryClient,
+            Utility utility,
             IGraphUtility graphUtility,
             ILogonActivity logonActivity,
             AppSettings appSettings,
@@ -57,6 +60,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         {
             this.configurationProvider = configurationProvider;
             this.telemetryClient = telemetryClient;
+            this.utility = utility;
             this.graphUtility = graphUtility;
             this.logonActivity = logonActivity;
             this.appSettings = appSettings;
@@ -255,22 +259,10 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
                 var workforceIntegrationRequest = this.CreateWorkforceIntegrationRequest(wfiDisplayName);
                 workforceIntegrationRegProps.Add("workforceIntegrationDisplayName", wfiDisplayName);
 
-                var clientId = this.appSettings.ClientId;
-                var instance = this.appSettings.Instance;
-                var clientSecret = this.appSettings.ClientSecret;
+                var graphConfigurationDetails = this.utility.GetTenantDetails();
+                graphConfigurationDetails.ShiftsAdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
 
-                var userId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
-                var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(
-                    tenantId,
-                    instance,
-                    clientId,
-                    clientSecret,
-                    userId).ConfigureAwait(false);
-
-                configurationEntity.WorkforceIntegrationSecret = workforceIntegrationRequest.Encryption.Secret;
-                configurationEntity.AdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
-
-                await this.configurationProvider.SaveOrUpdateConfigurationAsync(configurationEntity).ConfigureAwait(false);
+                var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
 
                 // Call the Graph API to register the workforce integration
                 var workforceIntegrationResponse = await this.graphUtility.RegisterWorkforceIntegrationAsync(
@@ -284,7 +276,8 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
                     var workforceIntegrationResponseObj = JsonConvert.DeserializeObject<WorkforceIntegrationEntity>(workforceResponse);
                     configurationEntity.WorkforceIntegrationId = workforceIntegrationResponseObj.Id;
                     configurationEntity.WorkforceIntegrationSecret = workforceIntegrationRequest.Encryption.Secret;
-                    configurationEntity.AdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
+                    configurationEntity.AdminAadObjectId = graphConfigurationDetails.ShiftsAdminAadObjectId;
+
                     await this.configurationProvider.SaveOrUpdateConfigurationAsync(configurationEntity).ConfigureAwait(false);
 
                     return this.RedirectToAction("Index", "Home").WithSuccess(Resources.WFIRegSuccessHeaderText, string.Format(CultureInfo.InvariantCulture, Resources.WFIRegSuccessContentText, workforceIntegrationResponseObj.DisplayName));
@@ -333,16 +326,14 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
                         configurationEntity?.WorkforceIntegrationId));
                 }
 
-                var clientId = this.appSettings.ClientId;
-                var instance = this.appSettings.Instance;
-                var clientSecret = this.appSettings.ClientSecret;
-                var userId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
+                var graphConfigurationDetails = this.utility.GetTenantDetails();
+                graphConfigurationDetails.ShiftsAdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
 
-                var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(tenantId, instance, clientId, clientSecret, userId).ConfigureAwait(false);
+                graphConfigurationDetails.ShiftsAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
 
                 var wfiDeletionResponse = await this.graphUtility.DeleteWorkforceIntegrationAsync(
                     configurationEntity?.WorkforceIntegrationId,
-                    graphAccessToken).ConfigureAwait(false);
+                    graphConfigurationDetails).ConfigureAwait(false);
 
                 if (!string.IsNullOrEmpty(wfiDeletionResponse))
                 {

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/TeamDepartmentMappingController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/TeamDepartmentMappingController.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         private readonly ILogonActivity logonActivity;
         private readonly IHyperFindLoadAllActivity hyperFindLoadAllActivity;
         private readonly ShiftsTeamKronosDepartmentViewModel shiftsTeamKronosDepartmentViewModel;
+        private readonly Utility utility;
         private readonly IGraphUtility graphUtility;
         private readonly AppSettings appSettings;
         private readonly IConfigurationProvider configurationProvider;
@@ -57,6 +58,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         /// <param name="logonActivity">Logon activity.</param>
         /// <param name="hyperFindLoadAllActivity">IHyperFindLoadAllActivity object.</param>
         /// <param name="shiftsTeamKronosDepartmentViewModel">ShiftsTeamKronosDepartmentViewModel object.</param>
+        /// <param name="utility">Utility DI.</param>
         /// <param name="graphUtility">Having the ability to DI the mechanism to get the token from MS Graph.</param>
         /// <param name="appSettings">Configuration DI.</param>
         /// <param name="configurationProvider">ConfigurationProvider DI.</param>
@@ -69,6 +71,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
             ILogonActivity logonActivity,
             IHyperFindLoadAllActivity hyperFindLoadAllActivity,
             ShiftsTeamKronosDepartmentViewModel shiftsTeamKronosDepartmentViewModel,
+            Utility utility,
             IGraphUtility graphUtility,
             AppSettings appSettings,
             IConfigurationProvider configurationProvider,
@@ -81,6 +84,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
             this.logonActivity = logonActivity;
             this.hyperFindLoadAllActivity = hyperFindLoadAllActivity;
             this.shiftsTeamKronosDepartmentViewModel = shiftsTeamKronosDepartmentViewModel;
+            this.utility = utility;
             this.graphUtility = graphUtility;
             this.appSettings = appSettings;
             this.configurationProvider = configurationProvider;
@@ -110,15 +114,8 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         /// <returns>A type of <see cref="IActionResult"/>.</returns>
         public async Task<IActionResult> SyncDataFirstTimeAsync()
         {
-            HttpRequestMessage request;
-
-            Task<HttpResponseMessage> syncKronosToShiftsResponse;
-
-            HttpResponseMessage syncKronosToShiftsResponseTask;
-
             var client = this.httpClientFactory.CreateClient("ShiftsKronosIntegrationAPI");
 
-            string errorMsgs = string.Empty;
             if (client.BaseAddress == null)
             {
                 client.BaseAddress = new Uri(this.appSettings.BaseAddressFirstTimeSync);
@@ -127,49 +124,35 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
             client.Timeout = TimeSpan.FromMinutes(30);
             var checkSetUp = await client.GetAsync(new Uri(client.BaseAddress + "api/teams/CheckSetup")).ConfigureAwait(false);
 
-            if (checkSetUp.IsSuccessStatusCode)
+            if (!checkSetUp.IsSuccessStatusCode)
             {
-                var clientId = this.appSettings.ClientId;
-                var instance = this.appSettings.Instance;
-                var clientSecret = this.appSettings.ClientSecret;
+                return this.RedirectToAction("Index").WithErrorMessage(Resources.ErrorNotificationHeaderText, Resources.SetUpNotDoneMessage);
+            }
 
-                var userId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
-                var tenantId = this.User.GetTenantId();
+            var graphConfigurationDetails = this.utility.GetTenantDetails();
+            graphConfigurationDetails.ShiftsAdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
+            graphConfigurationDetails.TenantId = this.User.GetTenantId();
 
-                var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(tenantId, instance, clientId, clientSecret, userId).ConfigureAwait(false);
+            var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
 
-                // Get JWT Token for API request
-                TokenHelper tokenHelper = new TokenHelper(this.appSettings);
-                string apiAccessToken = tokenHelper.GenerateToken();
+            // Get JWT Token for API request
+            TokenHelper tokenHelper = new TokenHelper(this.appSettings);
+            string apiAccessToken = tokenHelper.GenerateToken();
 
-                // Run sync Kronos to Shifts.
-                using (request = this.PrepareHttpRequest("api/SyncKronosToShifts/StartSync/false", graphAccessToken, apiAccessToken))
+            // Run sync Kronos to Shifts.
+            using (var request = this.PrepareHttpRequest("api/SyncKronosToShifts/StartSync/false", graphAccessToken, apiAccessToken))
+            {
+                var syncKronosToShiftsResponse = await client.SendAsync(request).ConfigureAwait(false);
+
+                if (!syncKronosToShiftsResponse.IsSuccessStatusCode)
                 {
-                    syncKronosToShiftsResponse = client.SendAsync(request);
-                    syncKronosToShiftsResponseTask = await syncKronosToShiftsResponse.ConfigureAwait(false);
-                    var syncKronosToShiftsStatus = syncKronosToShiftsResponseTask.StatusCode;
-                }
-
-                if (!syncKronosToShiftsResponseTask.IsSuccessStatusCode)
-                {
-                    var syncKronosToShiftsError = await syncKronosToShiftsResponseTask.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var syncKronosToShiftsError = await syncKronosToShiftsResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                     this.telemetryClient.TrackTrace($"{MethodBase.GetCurrentMethod().Name} error: " + syncKronosToShiftsError);
-                    errorMsgs += Resources.SyncKronosToShiftsError;
+                    return this.RedirectToAction("Index").WithErrorMessage(Resources.ErrorNotificationHeaderText, Resources.SyncKronosToShiftsError);
                 }
             }
-            else
-            {
-                errorMsgs += Resources.SetUpNotDoneMessage;
-            }
 
-            if (string.IsNullOrEmpty(errorMsgs))
-            {
-                return this.RedirectToAction("Index").WithSuccess(Resources.SuccessNotificationHeaderText, Resources.SetUpSuccessfulMessage);
-            }
-            else
-            {
-                return this.RedirectToAction("Index").WithErrorMessage(Resources.ErrorNotificationHeaderText, errorMsgs);
-            }
+            return this.RedirectToAction("Index").WithSuccess(Resources.SuccessNotificationHeaderText, Resources.SetUpSuccessfulMessage);
         }
 
         /// <summary>
@@ -230,14 +213,11 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
 
             if (wfi != null && !string.IsNullOrEmpty(wfi.WorkforceIntegrationId))
             {
-                var clientId = this.appSettings.ClientId;
-                var instance = this.appSettings.Instance;
-                var clientSecret = this.appSettings.ClientSecret;
+                var graphConfigurationDetails = this.utility.GetTenantDetails();
+                graphConfigurationDetails.ShiftsAdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
+                graphConfigurationDetails.TenantId = this.User.GetTenantId();
 
-                var userId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
-                var tenantId = this.User.GetTenantId();
-
-                var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(tenantId, instance, clientId, clientSecret, userId).ConfigureAwait(false);
+                graphConfigurationDetails.ShiftsAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
 
                 // Fetching the list of all distinct KronosOrgJobPaths
                 var kronosOrgJobPathList = await this.userMappingProvider.GetDistinctOrgJobPatAsync().ConfigureAwait(false);
@@ -250,13 +230,13 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
                 }
 
                 // Fetching the shift team details
-                var shiftTeamsList = await this.graphUtility.FetchShiftTeamDetailsAsync(graphAccessToken).ConfigureAwait(false);
+                var shiftTeamsList = await this.graphUtility.FetchShiftTeamDetailsAsync(graphConfigurationDetails).ConfigureAwait(false);
 
                 // Iterating the shift teams list to fetch the scheduling groups corrsponding to the shift teams id
                 foreach (var shiftTeam in shiftTeamsList)
                 {
                     // Fetching the scheduling group details
-                    var shiftSchedulingGroupDetailsResponse = await this.graphUtility.FetchSchedulingGroupDetailsAsync(graphAccessToken, shiftTeam.ShiftTeamId).ConfigureAwait(false);
+                    var shiftSchedulingGroupDetailsResponse = await this.graphUtility.FetchSchedulingGroupDetailsAsync(graphConfigurationDetails, shiftTeam.ShiftTeamId).ConfigureAwait(false);
 
                     var groupResponse = JsonConvert.DeserializeObject<SchedulingGroupDetails>(shiftSchedulingGroupDetailsResponse);
 
@@ -351,15 +331,12 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
 
                             if (isValidFile)
                             {
-                                var tenantId = this.appSettings.TenantId;
-                                var clientId = this.appSettings.ClientId;
-                                var clientSecret = this.appSettings.ClientSecret;
-                                var instance = this.appSettings.Instance;
+                                var graphConfigurationDetails = this.utility.GetTenantDetails();
+                                graphConfigurationDetails.ShiftsAdminAadObjectId = configEntity.AdminAadObjectId;
 
-                                var accessToken = await this.graphUtility.GetAccessTokenAsync(tenantId, instance, clientId, clientSecret, configEntity.AdminAadObjectId).ConfigureAwait(false);
-                                var graphClient = CreateGraphClientWithDelegatedAccess(accessToken);
+                                graphConfigurationDetails.ShiftsAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
 
-                                var isSuccess = await this.graphUtility.AddWFInScheduleAsync(entity.TeamId, graphClient, configEntity.WorkforceIntegrationId, accessToken).ConfigureAwait(false);
+                                var isSuccess = await this.graphUtility.AddWFInScheduleAsync(entity.TeamId, configEntity.WorkforceIntegrationId, graphConfigurationDetails).ConfigureAwait(false);
                                 if (isSuccess)
                                 {
                                     await this.teamDepartmentMappingProvider.SaveOrUpdateTeamsToDepartmentMappingAsync(entity).ConfigureAwait(false);
@@ -447,40 +424,6 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
                 kronosOrgJobPathDt?.Dispose();
                 shiftTeamsDt?.Dispose();
             }
-        }
-
-        /// <summary>
-        /// Method that creates the Microsoft Graph Service client.
-        /// </summary>
-        /// <param name="token">The Graph Access token.</param>
-        /// <returns>A type of <see cref="GraphServiceClient"/> contained in a unit of execution.</returns>
-        private static GraphServiceClient CreateGraphClientWithDelegatedAccess(string token)
-        {
-            if (string.IsNullOrEmpty(token))
-            {
-                throw new ArgumentNullException(token);
-            }
-
-            var graphClient = new GraphServiceClient(
-            new DelegateAuthenticationProvider(
-                (requestMessage) =>
-                {
-                    requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                    return Task.FromResult(0);
-                }));
-            return graphClient;
-        }
-
-        private void GetTenantDetails(
-            out string tenantId,
-            out string clientId,
-            out string clientSecret,
-            out string instance)
-        {
-            tenantId = this.appSettings.TenantId;
-            clientId = this.appSettings.ClientId;
-            clientSecret = this.appSettings.ClientSecret;
-            instance = this.appSettings.Instance;
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/UserMappingController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Controllers/UserMappingController.cs
@@ -337,26 +337,13 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration.Controllers
         /// <returns>A task.</returns>
         private async Task<List<ShiftUser>> GetAllShiftUsersAsync()
         {
-            var clientId = this.appSettings.ClientId;
-            var instance = this.appSettings.Instance;
-            var clientSecret = this.appSettings.ClientSecret;
+            var graphConfigurationDetails = this.utility.GetTenantDetails();
+            graphConfigurationDetails.ShiftsAdminAadObjectId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
+            graphConfigurationDetails.TenantId = this.User.GetTenantId();
 
-            var userId = this.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier").Value;
-            var tenantId = this.User.GetTenantId();
+            graphConfigurationDetails.ShiftsAccessToken = await this.graphUtility.GetAccessTokenAsync(graphConfigurationDetails).ConfigureAwait(false);
 
-            var graphAccessToken = await this.graphUtility.GetAccessTokenAsync(
-                tenantId,
-                instance,
-                clientId,
-                clientSecret,
-                userId).ConfigureAwait(false);
-
-            List<ShiftUser> teamsUserModels = new List<ShiftUser>();
-
-            teamsUserModels = await this.graphUtility.FetchShiftUserDetailsAsync(
-                graphAccessToken).ConfigureAwait(false);
-
-            return teamsUserModels;
+            return await this.graphUtility.FetchShiftUserDetailsAsync(graphConfigurationDetails).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Startup.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Startup.cs
@@ -248,6 +248,7 @@ namespace Microsoft.Teams.Shifts.Integration.Configuration
                 provider.GetRequiredService<ILogonActivity>(),
                 provider.GetRequiredService<IHyperFindLoadAllActivity>(),
                 provider.GetRequiredService<ShiftsTeamKronosDepartmentViewModel>(),
+                provider.GetRequiredService<Utility>(),
                 provider.GetRequiredService<IGraphUtility>(),
                 provider.GetRequiredService<AppSettings>(),
                 provider.GetRequiredService<BusinessLogic.Providers.IConfigurationProvider>(),


### PR DESCRIPTION
- Added a method in GraphUtility.cs which we now use to send all graph requests.
- This method will retry the request with a refreshed token in the event of an unauthorised response error.
- This should also fix the issue in the configuration app which required users to log in and out when a token expires.
- Removed places where we use a graph client to stay consistent.