### PR TITLE
Ktc/bugfix shifts remain in wrong team when team is updated

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/Utility.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/Utility.cs
@@ -212,21 +212,18 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
         /// <summary>
         /// Having the ability to create a new TeamsShiftMappingEntity.
         /// </summary>
-        /// <param name="aadUserId">AAD user Id associated with the Shift.</param>
         /// <param name="kronosUniqueId">Kronos Unique Id fro that Shift.</param>
-        /// <param name="kronosPersonNumber">Kronos Person number for the user.</param>
+        /// <param name="user">The user details.</param>
         /// <returns>Mapping Entity associated with Team and Shift.</returns>
-        public static TeamsShiftMappingEntity CreateShiftMappingEntity(
-            string aadUserId,
-            string kronosUniqueId,
-            string kronosPersonNumber)
+        public static TeamsShiftMappingEntity CreateShiftMappingEntity(string kronosUniqueId, UserDetailsModel user)
         {
             TeamsShiftMappingEntity teamsShiftMappingEntity = new TeamsShiftMappingEntity
             {
-                AadUserId = aadUserId,
+                AadUserId = user.ShiftUserId,
                 KronosUniqueId = kronosUniqueId,
-                KronosPersonNumber = kronosPersonNumber,
+                KronosPersonNumber = user.KronosPersonNumber,
                 ShiftStartDate = DateTime.UtcNow,
+                ShiftsTeamId = user.ShiftTeamId,
             };
 
             return teamsShiftMappingEntity;
@@ -307,7 +304,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
                 sb.Append(this.CalculateStartDateTime(item.StartDateTime, kronosTimeZone));
             }
 
-            var stringToHash = $"{this.CalculateStartDateTime(shift.SharedShift.StartDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}-{this.CalculateEndDateTime(shift.SharedShift.EndDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}{sb}{shift.SharedShift.Notes}{shift.UserId}";
+            var stringToHash = $"{this.CalculateStartDateTime(shift.SharedShift.StartDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}-{this.CalculateEndDateTime(shift.SharedShift.EndDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}{sb}{shift.SharedShift.Notes}{shift.UserId}{shift.SchedulingGroupId}";
 
             this.telemetryClient.TrackTrace($"String to create hash - Shift: {stringToHash}");
 
@@ -581,7 +578,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
                 { "ExecutingAssembly", Assembly.GetExecutingAssembly().GetName().Name },
             };
 
-            var stringToHash = $"{this.CalculateStartDateTime(startDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}-{this.CalculateEndDateTime(endDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}{sb}{shift.SharedShift.Notes}{shift.UserId}";
+            var stringToHash = $"{this.CalculateStartDateTime(startDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}-{this.CalculateEndDateTime(endDateTime, kronosTimeZone).ToString(CultureInfo.InvariantCulture)}{sb}{shift.SharedShift.Notes}{shift.UserId}{shift.SchedulingGroupId}";
 
             this.telemetryClient.TrackTrace($"String to create hash - Shift (IntegrationAPI Model): {stringToHash}");
 
@@ -907,11 +904,13 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
         /// <param name="shift">The Shift model.</param>
         /// <param name="userMappingEntity">Details of user from User Mapping Entity table.</param>
         /// <param name="kronosUniqueId">Kronos Unique Id corresponds to the shift.</param>
+        /// <param name="teamId">The id of the team the request came from.</param>
         /// <returns>Mapping Entity associated with Team and Shift.</returns>
         public TeamsShiftMappingEntity CreateShiftMappingEntity(
            Models.IntegrationAPI.Shift shift,
            AllUserMappingEntity userMappingEntity,
-           string kronosUniqueId)
+           string kronosUniqueId,
+           string teamId)
         {
             var startDateTime = DateTime.SpecifyKind(shift.SharedShift.StartDateTime, DateTimeKind.Utc);
 
@@ -921,6 +920,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Common
                 KronosUniqueId = kronosUniqueId,
                 KronosPersonNumber = userMappingEntity?.RowKey,
                 ShiftStartDate = startDateTime,
+                ShiftsTeamId = teamId,
             };
         }
 

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -766,7 +766,10 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
                 httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", configurationDetails.WFIId);
 
-                var requestUrl = $"teams/{item.ShiftsTeamId}/schedule/shifts/{item.RowKey}";
+                // If the shift mapping doesnt have a teamId take the users teamId
+                var teamId = string.IsNullOrEmpty(item.ShiftsTeamId) ? user.ShiftTeamId : item.ShiftsTeamId;
+
+                var requestUrl = $"teams/{teamId}/schedule/shifts/{item.RowKey}";
 
                 var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/ShiftController.cs
@@ -9,9 +9,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
     using System.Globalization;
     using System.Linq;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Reflection;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights;
@@ -20,7 +18,6 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
     using Microsoft.Teams.App.KronosWfc.BusinessLogic.Common;
     using Microsoft.Teams.App.KronosWfc.BusinessLogic.Shifts;
     using Microsoft.Teams.App.KronosWfc.Common;
-    using Microsoft.Teams.App.KronosWfc.Models.RequestEntities.Common;
     using Microsoft.Teams.App.KronosWfc.Models.ResponseEntities.HyperFind;
     using Microsoft.Teams.Shifts.Integration.API.Common;
     using Microsoft.Teams.Shifts.Integration.API.Models.Request;
@@ -94,11 +91,13 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// <param name="shift">The shift received from Shifts.</param>
         /// <param name="uniqueId">The unique ID for the shift.</param>
         /// <param name="kronoUserId">The user id of the user in Kronos.</param>
+        /// <param name="teamId">The team id.</param>
         /// <returns>Returns a <see cref="TeamsShiftMappingEntity"/>.</returns>
         public TeamsShiftMappingEntity CreateNewShiftMappingEntity(
             Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI.Shift shift,
             string uniqueId,
-            string kronoUserId)
+            string kronoUserId,
+            string teamId)
         {
             var createNewShiftMappingEntityProps = new Dictionary<string, string>()
             {
@@ -117,6 +116,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 KronosPersonNumber = kronoUserId,
                 ShiftStartDate = startDateTime,
                 ShiftEndDate = endDateTime,
+                ShiftsTeamId = teamId,
             };
 
             this.telemetryClient.TrackTrace("Creating new shift mapping entity.", createNewShiftMappingEntityProps);
@@ -417,7 +417,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         private async Task CreateAndStoreShiftMapping(ShiftsShift shift, AllUserMappingEntity user, TeamToDepartmentJobMappingEntity mappedTeam, List<string> monthPartitionKey)
         {
             var kronosUniqueId = this.utility.CreateShiftUniqueId(shift, mappedTeam.KronosTimeZone);
-            var shiftMappingEntity = this.CreateNewShiftMappingEntity(shift, kronosUniqueId, user.RowKey);
+            var shiftMappingEntity = this.CreateNewShiftMappingEntity(shift, kronosUniqueId, user.RowKey, mappedTeam.TeamId);
             await this.shiftMappingEntityProvider.SaveOrUpdateShiftMappingEntityAsync(shiftMappingEntity, shift.Id, monthPartitionKey[0]).ConfigureAwait(false);
         }
 
@@ -766,7 +766,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 var httpClient = this.httpClientFactory.CreateClient("ShiftsAPI");
                 httpClient.DefaultRequestHeaders.Add("X-MS-WFMPassthrough", configurationDetails.WFIId);
 
-                var requestUrl = $"teams/{user.ShiftTeamId}/schedule/shifts/{item.RowKey}";
+                var requestUrl = $"teams/{item.ShiftsTeamId}/schedule/shifts/{item.RowKey}";
 
                 var response = await this.graphUtility.SendHttpRequest(configurationDetails.GraphConfigurationDetails, httpClient, HttpMethod.Delete, requestUrl).ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -826,6 +826,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 KronosPersonNumber = user.KronosPersonNumber,
                 ShiftStartDate = startDateTime,
                 ShiftEndDate = endDateTime,
+                ShiftsTeamId = user.ShiftTeamId,
             };
 
             this.telemetryClient.TrackTrace("Creating new shift mapping entity.", createNewShiftMappingEntityProps);

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Models/TeamsShiftMappingEntity.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Common/Models/TeamsShiftMappingEntity.cs
@@ -36,5 +36,10 @@ namespace Microsoft.Teams.Shifts.Integration.BusinessLogic.Models
         /// Gets or Sets the shift start date.
         /// </summary>
         public DateTime ShiftEndDate { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the team id that this shift belongs to.
+        /// </summary>
+        public string ShiftsTeamId { get; set; }
     }
 }

--- a/Kronos-Shifts-Connector/ReleaseNotes.md
+++ b/Kronos-Shifts-Connector/ReleaseNotes.md
@@ -42,7 +42,20 @@ Please note that open shifts share the commentText value used for shift notes.
 **Bugfixes**
 
 - Improvements to how we handle graph tokens allowing us to retry failed requests in the event of an expired token
-- Fixed the issue where a users shifts would not be deleted in the old team if they move to a new team - Please ensure you clear the shift mapping cache as we need the new 'TeamId' column to be populated which is done during the creation of each shift.
+
+- Fixed the issue where a users shifts would not be deleted in the old team if they move to a new team 
+
+  *We are aware of an issue that will prevent this fix from working on existing shifts. For example:*
+
+  *1- A shift is created and stored in cache before this fix is deployed*
+
+  *2- The fix is then deployed in your environment*
+
+  *3- The user then changes team*
+
+  *4- The existing shift will fail to be deleted*
+
+  *This will only be a problem for existing shifts, newly created shifts will have the TeamId column in cache populated and be deleted successfully.*
 
 ### 30th September 2021
 

--- a/Kronos-Shifts-Connector/ReleaseNotes.md
+++ b/Kronos-Shifts-Connector/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-### 21st October 2021
+### 4th November 2021
 
 ------
 
@@ -42,6 +42,7 @@ Please note that open shifts share the commentText value used for shift notes.
 **Bugfixes**
 
 - Improvements to how we handle graph tokens allowing us to retry failed requests in the event of an expired token
+- Fixed the issue where a users shifts would not be deleted in the old team if they move to a new team - Please ensure you clear the shift mapping cache as we need the new 'TeamId' column to be populated which is done during the creation of each shift.
 
 ### 30th September 2021
 


### PR DESCRIPTION
When a user was moved to a new team in Teams there old shifts would remain in the old team. This was due to the fact that when attempting to delete them we were using the users current team id rather than the team id that the shift was created in.